### PR TITLE
Extract the column modification from the add_id_seq.sql

### DIFF
--- a/utility/add_alter_columns.sql
+++ b/utility/add_alter_columns.sql
@@ -1,0 +1,12 @@
+--
+-- The database seems to have multiple schemas, and the tables
+-- are created in public schema.
+--
+SET search_path=public;
+
+--
+-- The version of database we have are missing following changes that are needed
+--
+
+ALTER TABLE lajihavainto ADD COLUMN hav_koodi VARCHAR(100);
+ALTER TABLE lajirekisteri ALTER COLUMN koodi TYPE VARCHAR(100);

--- a/utility/add_id_seq.sql
+++ b/utility/add_id_seq.sql
@@ -10,14 +10,6 @@
 --
 SET search_path=public;
 
-
---
--- The version of database we have are missing following changes that are needed
---
-
-ALTER TABLE lajihavainto ADD COLUMN IF NOT EXISTS hav_koodi VARCHAR(100);
-ALTER TABLE lajirekisteri ALTER COLUMN koodi TYPE VARCHAR(100);
-
 --
 -- Add sequences to id fields
 --


### PR DESCRIPTION
Postgres version 9.5 and below does not support ADD COLUMN IF NOT EXIST synx. We relocate the column change script to sperate sql file so they both can be repeated.