### PR TITLE
Replace the munigeo.api.GeoModelSerializer with djangorestframework_gis

### DIFF
--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -40,8 +40,8 @@ INSTALLED_APPS = [
     'django.contrib.gis',
     'ckeditor',
     'rest_framework',
+    'rest_framework_gis',
     'nature',
-    'munigeo'
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/nature/api.py
+++ b/nature/api.py
@@ -2,7 +2,6 @@ from django.core.exceptions import FieldError
 from rest_framework.fields import SerializerMethodField
 from rest_framework.reverse import reverse
 from rest_framework import serializers, viewsets, routers, relations
-from munigeo.api import GeoModelSerializer
 
 from nature.models import (
     ProtectionLevelMixin,
@@ -125,7 +124,7 @@ class ProtectionSerializer(ProtectedHyperlinkedModelSerializer):
                   'criteria', 'conservation_programmes')
 
 
-class FeatureSerializer(ProtectedHyperlinkedModelSerializer, GeoModelSerializer):
+class FeatureSerializer(ProtectedHyperlinkedModelSerializer):
     square = SquareSerializer()
     protection = ProtectionSerializer()
     text = SerializerMethodField()

--- a/nature/api.py
+++ b/nature/api.py
@@ -1,7 +1,9 @@
+from django.contrib.gis.db.models.functions import Transform
 from django.core.exceptions import FieldError
 from rest_framework.fields import SerializerMethodField
 from rest_framework.reverse import reverse
 from rest_framework import serializers, viewsets, routers, relations
+from rest_framework_gis.fields import GeometryField
 
 from nature.models import (
     ProtectionLevelMixin,
@@ -128,6 +130,7 @@ class FeatureSerializer(ProtectedHyperlinkedModelSerializer):
     square = SquareSerializer()
     protection = ProtectionSerializer()
     text = SerializerMethodField()
+    geometry = GeometryField(source='geom')  # using transformed geometry
 
     def get_text(self, obj):
         # now this is a silly feature: text should not be public if text_www exists
@@ -268,7 +271,7 @@ class HabitatTypeObservationSerializer(ProtectedHyperlinkedModelSerializer):
 
 
 class FeatureViewSet(ProtectedViewSet):
-    queryset = Feature.objects.all()
+    queryset = Feature.objects.all().annotate(geom=Transform('geometry', 4326))  # display coordinates in WGS84
     serializer_class = FeatureSerializer
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ appnope==0.1.0
 decorator==4.1.2
 Django==1.11.4
 djangorestframework==3.6.3
+djangorestframework-gis==0.11.2
 django-ckeditor==5.3.1
 ipython==6.1.0
 ipython-genutils==0.2.0


### PR DESCRIPTION
munigeo will create extra database tables that are not needed, and requires languages to be defined in settings.