### PR TITLE
Update 0001_initial.py

### DIFF
--- a/nature/migrations/0001_initial.py
+++ b/nature/migrations/0001_initial.py
@@ -129,8 +129,8 @@ class Migration(migrations.Migration):
                 ('last_modified_time', models.DateTimeField(auto_now=True, db_column='pvm_editoitu', null=True)),
                 ('last_modified_by', models.CharField(blank=True, db_column='muokkaaja', max_length=10, null=True)),
                 ('area', models.FloatField(verbose_name='Area (ha)', editable=False, blank=True, db_column='pinta_ala', null=True)),
-                ('text', models.CharField(blank=True, db_column='teksti', max_length=4000, null=True)),
-                ('text_www', models.CharField(blank=True, db_column='teksti_www', max_length=4000, null=True)),
+                ('text', models.CharField(blank=True, db_column='teksti', max_length=40000, null=True)),
+                ('text_www', models.CharField(blank=True, db_column='teksti_www', max_length=40000, null=True)),
             ],
             options={
                 'db_table': 'kohde',


### PR DESCRIPTION
Tässä toinen, joka ei myöskään ollut lähtenyt 25.1. t. Sanna
........................................................
Moi, testatessa tuli vastaan, että sovelluksessa kohde-taulun kenttiin text ja text_www ei mahdu 4000 merkkiä pidempiä tekstejä. Kannassa pituus on määritelty 40000:ksi, kantakuvassa pituus on virheellisesti 4000.
t. Sanna