### PR TITLE
Upgrade openlayers to latest version and use basemap from kartta.hel.fi wmts service

### DIFF
--- a/nature/admin.py
+++ b/nature/admin.py
@@ -82,20 +82,10 @@ class FeatureAdmin(admin.GeoModelAdmin):
     form = FeatureForm
     inlines = [ObservationInline, FeatureLinkInline, FeaturePublicationInline]
     actions = None
+
     widget = NatureOLWidget
     map_template = 'nature/openlayers-nature.html'
     openlayers_url = 'https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.js'
-
-    # map configs
-    map_width = 800
-    map_height = 600
-
-    # OSMGeoAdmin uses web mercator projection (EPSG:3857)
-    default_lon = 25496731.185709
-    default_lat = 6672620.498890
-    default_zoom = 12
-
-    map_srid = settings.SRID
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/nature/admin.py
+++ b/nature/admin.py
@@ -1,5 +1,4 @@
 from django.contrib.gis import admin
-from django.conf import settings
 
 from .models import (
     Feature, FeatureClass, FeatureLink, FeaturePublication,

--- a/nature/admin.py
+++ b/nature/admin.py
@@ -1,4 +1,5 @@
 from django.contrib.gis import admin
+from django.conf import settings
 
 from .models import (
     Feature, FeatureClass, FeatureLink, FeaturePublication,
@@ -6,6 +7,7 @@ from .models import (
     Species, LinkType,
 )
 from .forms import FeatureForm
+from .widgets import NatureOLWidget
 
 
 @admin.register(Species)
@@ -72,7 +74,7 @@ class FeaturePublicationInline(admin.TabularInline):
 
 
 @admin.register(Feature)
-class FeatureAdmin(admin.OSMGeoAdmin):
+class FeatureAdmin(admin.GeoModelAdmin):
     readonly_fields = ('_area', 'created_by', 'created_time', 'last_modified_by', 'last_modified_time')
     list_display = ('id', 'feature_class', 'fid', 'name', 'active')
     search_fields = ('feature_class__name', 'name', 'fid', 'id')
@@ -80,15 +82,20 @@ class FeatureAdmin(admin.OSMGeoAdmin):
     form = FeatureForm
     inlines = [ObservationInline, FeatureLinkInline, FeaturePublicationInline]
     actions = None
+    widget = NatureOLWidget
+    map_template = 'nature/openlayers-nature.html'
+    openlayers_url = 'https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.js'
 
     # map configs
     map_width = 800
     map_height = 600
 
     # OSMGeoAdmin uses web mercator projection (EPSG:3857)
-    default_lon = 2776541.611259
-    default_lat = 8437840.556572
+    default_lon = 25496731.185709
+    default_lat = 6672620.498890
     default_zoom = 12
+
+    map_srid = settings.SRID
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -1,0 +1,231 @@
+/* global ol */
+
+var GeometryTypeControl = function(opt_options) {
+    'use strict';
+    // Map control to switch type when geometry type is unknown
+    var options = opt_options || {};
+
+    var element = document.createElement('div');
+    element.className = 'switch-type type-' + options.type + ' ol-control ol-unselectable';
+    if (options.active) {
+        element.className += " type-active";
+    }
+
+    var self = this;
+    var switchType = function(e) {
+        e.preventDefault();
+        if (options.widget.currentGeometryType !== self) {
+            options.widget.map.removeInteraction(options.widget.interactions.draw);
+            options.widget.interactions.draw = new ol.interaction.Draw({
+                features: options.widget.featureCollection,
+                type: options.type
+            });
+            options.widget.map.addInteraction(options.widget.interactions.draw);
+            var className = options.widget.currentGeometryType.element.className.replace(/ type-active/g, '');
+            options.widget.currentGeometryType.element.className = className;
+            options.widget.currentGeometryType = self;
+            element.className += " type-active";
+        }
+    };
+
+    element.addEventListener('click', switchType, false);
+    element.addEventListener('touchstart', switchType, false);
+
+    ol.control.Control.call(this, {
+        element: element
+    });
+};
+ol.inherits(GeometryTypeControl, ol.control.Control);
+
+// TODO: allow deleting individual features (#8972)
+(function() {
+    'use strict';
+    var jsonFormat = new ol.format.GeoJSON();
+
+    function MapWidget(options) {
+        this.map = null;
+        this.interactions = {draw: null, modify: null};
+        this.typeChoices = false;
+        this.ready = false;
+
+        // Default options
+        this.options = {
+            default_lat: 0,
+            default_lon: 0,
+            default_zoom: 12,
+            is_collection: options.geom_name.indexOf('Multi') > -1 || options.geom_name.indexOf('Collection') > -1
+        };
+
+        // Altering using user-provided options
+        for (var property in options) {
+            if (options.hasOwnProperty(property)) {
+                this.options[property] = options[property];
+            }
+        }
+        if (!options.base_layer) {
+            this.options.base_layer = new ol.layer.Tile({source: new ol.source.OSM()});
+        }
+
+        this.map = this.createMap();
+        this.featureCollection = new ol.Collection();
+        this.featureOverlay = new ol.layer.Vector({
+            map: this.map,
+            source: new ol.source.Vector({
+                features: this.featureCollection,
+                useSpatialIndex: false // improve performance
+            }),
+            updateWhileAnimating: true, // optional, for instant visual feedback
+            updateWhileInteracting: true // optional, for instant visual feedback
+        });
+
+        // Populate and set handlers for the feature container
+        var self = this;
+        this.featureCollection.on('add', function(event) {
+            var feature = event.element;
+            feature.on('change', function() {
+                self.serializeFeatures();
+            });
+            if (self.ready) {
+                self.serializeFeatures();
+                if (!self.options.is_collection) {
+                    self.disableDrawing(); // Only allow one feature at a time
+                }
+            }
+        });
+
+        var initial_value = document.getElementById(this.options.id).value;
+        if (initial_value) {
+            var features = jsonFormat.readFeatures('{"type": "Feature", "geometry": ' + initial_value + '}');
+            var extent = ol.extent.createEmpty();
+            features.forEach(function(feature) {
+                this.featureOverlay.getSource().addFeature(feature);
+                ol.extent.extend(extent, feature.getGeometry().getExtent());
+            }, this);
+            // Center/zoom the map
+            this.map.getView().fit(extent, {maxZoom: this.options.default_zoom});
+        } else {
+            this.map.getView().setCenter(this.defaultCenter());
+        }
+        this.createInteractions();
+        if (initial_value && !this.options.is_collection) {
+            this.disableDrawing();
+        }
+        this.ready = true;
+    }
+
+    MapWidget.prototype.createMap = function() {
+        var map = new ol.Map({
+            target: this.options.map_id,
+            layers: [this.options.base_layer],
+            view: new ol.View({
+                zoom: this.options.default_zoom
+            })
+        });
+        return map;
+    };
+
+    MapWidget.prototype.createInteractions = function() {
+        // Initialize the modify interaction
+        this.interactions.modify = new ol.interaction.Modify({
+            features: this.featureCollection,
+            deleteCondition: function(event) {
+                return ol.events.condition.shiftKeyOnly(event) &&
+                    ol.events.condition.singleClick(event);
+            }
+        });
+
+        // Initialize the draw interaction
+        var geomType = this.options.geom_name;
+        if (geomType === "Unknown" || geomType === "GeometryCollection") {
+            // Default to Point, but create icons to switch type
+            geomType = "Point";
+            this.currentGeometryType = new GeometryTypeControl({widget: this, type: "Point", active: true});
+            this.map.addControl(this.currentGeometryType);
+            this.map.addControl(new GeometryTypeControl({widget: this, type: "LineString", active: false}));
+            this.map.addControl(new GeometryTypeControl({widget: this, type: "Polygon", active: false}));
+            this.typeChoices = true;
+        }
+        this.interactions.draw = new ol.interaction.Draw({
+            features: this.featureCollection,
+            type: geomType
+        });
+
+        this.map.addInteraction(this.interactions.draw);
+        this.map.addInteraction(this.interactions.modify);
+    };
+
+    MapWidget.prototype.defaultCenter = function() {
+        var center = [this.options.default_lon, this.options.default_lat];
+        if (this.options.map_srid) {
+            return ol.proj.transform(center, 'EPSG:4326', this.map.getView().getProjection());
+        }
+        return center;
+    };
+
+    MapWidget.prototype.enableDrawing = function() {
+        this.interactions.draw.setActive(true);
+        if (this.typeChoices) {
+            // Show geometry type icons
+            var divs = document.getElementsByClassName("switch-type");
+            for (var i = 0; i !== divs.length; i++) {
+                divs[i].style.visibility = "visible";
+            }
+        }
+    };
+
+    MapWidget.prototype.disableDrawing = function() {
+        if (this.interactions.draw) {
+            this.interactions.draw.setActive(false);
+            if (this.typeChoices) {
+                // Hide geometry type icons
+                var divs = document.getElementsByClassName("switch-type");
+                for (var i = 0; i !== divs.length; i++) {
+                    divs[i].style.visibility = "hidden";
+                }
+            }
+        }
+    };
+
+    MapWidget.prototype.clearFeatures = function() {
+        this.featureCollection.clear();
+        // Empty textarea widget
+        document.getElementById(this.options.id).value = '';
+        this.enableDrawing();
+    };
+
+    MapWidget.prototype.serializeFeatures = function() {
+        // Three use cases: GeometryCollection, multigeometries, and single geometry
+        var geometry = null;
+        var features = this.featureOverlay.getSource().getFeatures();
+        if (this.options.is_collection) {
+            if (this.options.geom_name === "GeometryCollection") {
+                var geometries = [];
+                for (var i = 0; i < features.length; i++) {
+                    geometries.push(features[i].getGeometry());
+                }
+                geometry = new ol.geom.GeometryCollection(geometries);
+            } else {
+                geometry = features[0].getGeometry().clone();
+                for (var j = 1; j < features.length; j++) {
+                    switch(geometry.getType()) {
+                        case "MultiPoint":
+                            geometry.appendPoint(features[j].getGeometry().getPoint(0));
+                            break;
+                        case "MultiLineString":
+                            geometry.appendLineString(features[j].getGeometry().getLineString(0));
+                            break;
+                        case "MultiPolygon":
+                            geometry.appendPolygon(features[j].getGeometry().getPolygon(0));
+                    }
+                }
+            }
+        } else {
+            if (features[0]) {
+                geometry = features[0].getGeometry();
+            }
+        }
+        document.getElementById(this.options.id).value = jsonFormat.writeGeometry(geometry);
+    };
+
+    window.MapWidget = MapWidget;
+})();

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -1,4 +1,10 @@
-/* global ol */
+/**
+ * @file This is a modified version of OLMapWidget.js provided by Django
+ * to support the needs of feature geometry editing.
+ *
+ * List of modifications:
+ * - Set map projection to EPSG:3879
+ */
 
 var GeometryTypeControl = function(opt_options) {
     'use strict';
@@ -37,7 +43,6 @@ var GeometryTypeControl = function(opt_options) {
 };
 ol.inherits(GeometryTypeControl, ol.control.Control);
 
-// TODO: allow deleting individual features (#8972)
 (function() {
     'use strict';
     var jsonFormat = new ol.format.GeoJSON();

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -114,11 +114,20 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
     }
 
     MapWidget.prototype.createMap = function() {
+        var projection = new ol.proj.Projection({
+            code: 'EPSG:3879',
+            extent: [21531406.93, 4503686.78, 25664437.76, 9371843.41],
+            units: 'm'
+        });
+        ol.proj.addProjection(projection);
+
         var map = new ol.Map({
             target: this.options.map_id,
             layers: [this.options.base_layer],
             view: new ol.View({
-                zoom: this.options.default_zoom
+                projection: projection,
+                zoom: this.options.default_zoom,
+                extent: [25440000.0, 6630000.0, 25571072.0, 6761072.0]
             })
         });
         return map;

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -55,8 +55,8 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
 
         // Default options
         this.options = {
-            default_lat: 0,
-            default_lon: 0,
+            default_y: 0,
+            default_x: 0,
             default_zoom: 12,
             is_collection: options.geom_name.indexOf('Multi') > -1 || options.geom_name.indexOf('Collection') > -1
         };
@@ -169,10 +169,7 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
     };
 
     MapWidget.prototype.defaultCenter = function() {
-        var center = [this.options.default_lon, this.options.default_lat];
-        if (this.options.map_srid) {
-            return ol.proj.transform(center, 'EPSG:4326', this.map.getView().getProjection());
-        }
+        var center = [this.options.default_x, this.options.default_y];
         return center;
     };
 

--- a/nature/templates/nature/openlayers-nature.html
+++ b/nature/templates/nature/openlayers-nature.html
@@ -4,6 +4,7 @@
 {% block options %}{{ block.super }}
 options['default_lon'] = {{ default_lon|unlocalize }};
 options['default_lat'] = {{ default_lat|unlocalize }};
+options['default_zoom'] = {{ default_zoom|unlocalize }};
 {% endblock %}
 
 {% block base_layer %}

--- a/nature/templates/nature/openlayers-nature.html
+++ b/nature/templates/nature/openlayers-nature.html
@@ -1,0 +1,11 @@
+{% extends "gis/openlayers.html" %}
+{% load l10n %}
+
+{% block options %}{{ block.super }}
+options['default_lon'] = {{ default_lon|unlocalize }};
+options['default_lat'] = {{ default_lat|unlocalize }};
+{% endblock %}
+
+{% block base_layer %}
+var base_layer = new ol.layer.Tile({source: new ol.source.OSM()});
+{% endblock %}

--- a/nature/templates/nature/openlayers-nature.html
+++ b/nature/templates/nature/openlayers-nature.html
@@ -7,5 +7,20 @@ options['default_lat'] = {{ default_lat|unlocalize }};
 {% endblock %}
 
 {% block base_layer %}
-var base_layer = new ol.layer.Tile({source: new ol.source.OSM()});
+var base_layer = new ol.layer.Tile({
+    source: new ol.source.WMTS({
+        url: 'https://kartta.hel.fi/ws/geoserver/avoindata/gwc/service/wmts',
+        layer: 'avoindata:Opaskartta_Helsinki',
+        format: 'image/png',
+        matrixSet: 'ETRS-GK25',
+        tileGrid: new ol.tilegrid.WMTS({
+            tileSize: [256, 256],
+            extent: [2.544E7,6630000.0,2.5571072E7,6761072.0],
+            origin: [2.544E7, 6761072.0],
+            resolutions: [256.0, 128.0, 64.0, 32.0, 16.0, 8.0, 4.0, 2.0, 1.0, 0.5, 0.25, 0.125, 0.0625],
+            matrixIds: ['ETRS-GK25:0', 'ETRS-GK25:1', 'ETRS-GK25:2', 'ETRS-GK25:3', 'ETRS-GK25:4', 'ETRS-GK25:5', 'ETRS-GK25:6', 'ETRS-GK25:7', 'ETRS-GK25:8', 'ETRS-GK25:9', 'ETRS-GK25:10', 'ETRS-GK25:11', 'ETRS-GK25:12']
+        }),
+        wrapX: true
+    })
+});
 {% endblock %}

--- a/nature/templates/nature/openlayers-nature.html
+++ b/nature/templates/nature/openlayers-nature.html
@@ -2,8 +2,8 @@
 {% load l10n %}
 
 {% block options %}{{ block.super }}
-options['default_lon'] = {{ default_lon|unlocalize }};
-options['default_lat'] = {{ default_lat|unlocalize }};
+options['default_x'] = {{ default_x|unlocalize }};
+options['default_y'] = {{ default_y|unlocalize }};
 options['default_zoom'] = {{ default_zoom|unlocalize }};
 {% endblock %}
 

--- a/nature/tests/test_widgets.py
+++ b/nature/tests/test_widgets.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from ..widgets import NatureOLWidget
+
+
+class MockNatureOLWidget(NatureOLWidget):
+    default_lon = 111
+    default_lat = 222
+    default_zoom = 5
+
+
+class TestNatureOLWidget(TestCase):
+
+    def test_required_attributes_are_set(self):
+        widget = MockNatureOLWidget()
+        expected_attr_subset = {
+            'default_lon': 111,
+            'default_lat': 222,
+            'default_zoom': 5,
+        }
+        self.assertGreater(widget.attrs.items(), expected_attr_subset.items())
+
+    def test_init_can_override_default_attrs(self):
+        attrs = {
+            'default_lon': 888,
+            'default_lat': 999,
+            'default_zoom': 7,
+        }
+        widget = MockNatureOLWidget(attrs)
+        self.assertGreater(widget.attrs.items(), attrs.items())

--- a/nature/tests/test_widgets.py
+++ b/nature/tests/test_widgets.py
@@ -4,8 +4,8 @@ from ..widgets import NatureOLWidget
 
 
 class MockNatureOLWidget(NatureOLWidget):
-    default_lon = 111
-    default_lat = 222
+    default_x = 111
+    default_y = 222
     default_zoom = 5
 
 
@@ -14,16 +14,16 @@ class TestNatureOLWidget(TestCase):
     def test_required_attributes_are_set(self):
         widget = MockNatureOLWidget()
         expected_attr_subset = {
-            'default_lon': 111,
-            'default_lat': 222,
+            'default_x': 111,
+            'default_y': 222,
             'default_zoom': 5,
         }
         self.assertGreater(widget.attrs.items(), expected_attr_subset.items())
 
     def test_init_can_override_default_attrs(self):
         attrs = {
-            'default_lon': 888,
-            'default_lat': 999,
+            'default_x': 888,
+            'default_y': 999,
             'default_zoom': 7,
         }
         widget = MockNatureOLWidget(attrs)

--- a/nature/widgets.py
+++ b/nature/widgets.py
@@ -6,8 +6,8 @@ class NatureOLWidget(OpenLayersWidget):
     template_name = 'nature/openlayers-nature.html'
     map_width = 800
     map_height = 600
-    default_lon = 25496615.87
-    default_lat = 6672343.32
+    default_x = 25496615.87
+    default_y = 6672343.32
     default_zoom = 12
     map_srid = settings.SRID
 
@@ -26,7 +26,7 @@ class NatureOLWidget(OpenLayersWidget):
 
     def __init__(self, attrs=None):
         super().__init__()
-        for key in ('default_lon', 'default_lat', 'default_zoom'):
+        for key in ('default_x', 'default_y', 'default_zoom'):
             self.attrs[key] = getattr(self, key)
         if attrs:
             self.attrs.update(attrs)

--- a/nature/widgets.py
+++ b/nature/widgets.py
@@ -1,0 +1,23 @@
+from django.contrib.gis.forms.widgets import OSMWidget
+from django.conf import settings
+
+
+class NatureOLWidget(OSMWidget):
+    template_name = 'nature/openlayers-nature.html'
+    map_srid = settings.SRID
+
+    default_lon = 25496731.185709
+    default_lat = 6672620.498890
+
+    class Media:
+        extend = False
+        css = {
+            'all': (
+                'https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.css',
+                'gis/css/ol3.css',
+            )
+        }
+        js = (
+            'https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.js',
+            'nature/js/NatureOLMapWidget.js',
+        )

--- a/nature/widgets.py
+++ b/nature/widgets.py
@@ -1,13 +1,15 @@
-from django.contrib.gis.forms.widgets import OSMWidget
+from django.contrib.gis.forms.widgets import OpenLayersWidget
 from django.conf import settings
 
 
-class NatureOLWidget(OSMWidget):
+class NatureOLWidget(OpenLayersWidget):
     template_name = 'nature/openlayers-nature.html'
+    map_width = 800
+    map_height = 600
+    default_lon = 25496615.87
+    default_lat = 6672343.32
+    default_zoom = 12
     map_srid = settings.SRID
-
-    default_lon = 25496731.185709
-    default_lat = 6672620.498890
 
     class Media:
         extend = False
@@ -21,3 +23,10 @@ class NatureOLWidget(OSMWidget):
             'https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.js',
             'nature/js/NatureOLMapWidget.js',
         )
+
+    def __init__(self, attrs=None):
+        super().__init__()
+        for key in ('default_lon', 'default_lat', 'default_zoom'):
+            self.attrs[key] = getattr(self, key)
+        if attrs:
+            self.attrs.update(attrs)


### PR DESCRIPTION
It  upgrades the openlayers version to the latest for feature geometry editing, and replace the default map to the wmts basemap.

This is the first step to implement #36. Django map widget and its template do not support multiple base layers and there's no built-in layer switcher in new version of openlayers. We need to tweak the widget and templates more and add a layer switcher to it.

![geometry-field](https://user-images.githubusercontent.com/1997039/41335817-ce528586-6ef2-11e8-9b12-04ee0153a195.png)

Refs: #36 