### PR TITLE
Actually set STATIC_ROOT and MEDIA_ROOT

### DIFF
--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -26,6 +26,10 @@ DEBUG = env('DEBUG')
 ALLOWED_HOSTS = env('ALLOWED_HOSTS')
 ADMINS = env('ADMINS')
 
+STATIC_URL = env('STATIC_URL')
+MEDIA_URL = env('MEDIA_URL')
+STATIC_ROOT = env('STATIC_ROOT')
+MEDIA_ROOT = env('MEDIA_ROOT')
 
 # Application definition
 


### PR DESCRIPTION
Current config does not actually set STATIC_{ROOT,URL} and MEDIA_{ROOT,URL}. They still need to be extracted from their variables.

Done using github editor, please double check.