### PR TITLE
Add a LOGGING configuration with output to stderr

### DIFF
--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -11,29 +11,7 @@ env = environ.Env(
     DATABASE_URL=(str, 'postgis:///ltj'),
     MEDIA_ROOT=(environ.Path(), root('media')),
     STATIC_ROOT=(environ.Path(), root('static')),
-    MEDIA_URL=(str, '/media/
-               # log to stderr, at level INFO and add timestamps
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'timestamped': {
-            'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
-        },
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'timestamped',
-            'level': 'INFO',
-        },
-    },
-    'root': {
-        'handlers': ['console'],
-        'level': env('LOG_LEVEL'),
-    },
-}
-               '),
+    MEDIA_URL=(str, '/media/'),
     STATIC_URL=(str, '/static/'),
     LOG_LEVEL=(str, 'INFO'),
 )

--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -11,8 +11,31 @@ env = environ.Env(
     DATABASE_URL=(str, 'postgis:///ltj'),
     MEDIA_ROOT=(environ.Path(), root('media')),
     STATIC_ROOT=(environ.Path(), root('static')),
-    MEDIA_URL=(str, '/media/'),
+    MEDIA_URL=(str, '/media/
+               # log to stderr, at level INFO and add timestamps
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'timestamped': {
+            'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'timestamped',
+            'level': 'INFO',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': env('LOG_LEVEL'),
+    },
+}
+               '),
     STATIC_URL=(str, '/static/'),
+    LOG_LEVEL=(str, 'INFO'),
 )
 
 # .env file, should load only in development environment
@@ -30,6 +53,28 @@ STATIC_URL = env('STATIC_URL')
 MEDIA_URL = env('MEDIA_URL')
 STATIC_ROOT = env('STATIC_ROOT')
 MEDIA_ROOT = env('MEDIA_ROOT')
+
+# log to stderr, at level specified by LOG_LEVEL and add metadata
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'metadata': {
+            'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'metadata',
+            'level': env('LOG_LEVEL'),
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': env('LOG_LEVEL'),
+    },
+}
 
 # Application definition
 


### PR DESCRIPTION
Default Django logging (non-debug) only mails the admins. We want to send events to stderr. From there they can either be captured by the environment or seen by developer