### PR TITLE
Map controls

### DIFF
--- a/nature/static/nature/css/nature-ol.css
+++ b/nature/static/nature/css/nature-ol.css
@@ -2,3 +2,10 @@
     margin-left: 0;
     padding-left: 1em;
 }
+
+.nature-mouse-position {
+    bottom: 35px;
+    right: 8px;
+    font-size: 12px;
+    position: absolute;
+}

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -5,6 +5,7 @@
  * List of modifications:
  * - Set map projection to EPSG:3879
  * - Add custom base maps (WMTS)
+ * - Coordinates at mouse
  */
 
 var GeometryTypeControl = function(opt_options) {
@@ -171,6 +172,15 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
             tipLabel: 'Layers'
         });
         map.addControl(layerSwitcher);
+
+
+        // Add mouse position coordiantes
+        var mousePositionControl = new ol.control.MousePosition({
+            coordinateFormat: ol.coordinate.createStringXY(4),
+            projection: 'EPSG:3879',
+            className: 'nature-mouse-position'
+        });
+        map.addControl(mousePositionControl);
 
         return map;
     };

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -5,6 +5,7 @@
  * List of modifications:
  * - Set map projection to EPSG:3879
  * - Add custom base maps (WMTS)
+ * - Scale bar
  * - Coordinates at mouse
  */
 
@@ -181,6 +182,12 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
             className: 'nature-mouse-position'
         });
         map.addControl(mousePositionControl);
+
+        // Add scale line
+        var scaleLineControl = new ol.control.ScaleLine({
+            units: 'metric',
+        });
+        map.addControl(scaleLineControl);
 
         return map;
     };

--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -169,6 +169,7 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
             })
         });
 
+        // Add layer switcher
         var layerSwitcher = new ol.control.LayerSwitcher({
             tipLabel: 'Layers'
         });


### PR DESCRIPTION
Add scale bar and coordinates to map.

The coordinates can of course still be moved around if this is not the best place. I just placed them as close to the previous position as possible, but since there is now the "info" entry at the bottom right I had to move the coordinates up a bit.

Fixes https://github.com/City-of-Helsinki/ltj/issues/51, https://github.com/City-of-Helsinki/ltj/issues/45