### PR TITLE
Adding protection fields to protected features

### DIFF
--- a/nature/admin.py
+++ b/nature/admin.py
@@ -98,6 +98,8 @@ class HabitatTypeObservationInline(admin.TabularInline):
 
 
 class ProtectionInline(admin.StackedInline):
+    verbose_name = _('protection')
+    verbose_name_plural = _('protection')  # protection has one to one relationship to feature
     model = Protection
     form = ProtectionInlineForm
     max_num = 1

--- a/nature/admin.py
+++ b/nature/admin.py
@@ -5,8 +5,11 @@ from .models import (
     Feature, FeatureClass, FeatureLink, FeaturePublication,
     Observation, ObservationSeries, Publication,
     Species, LinkType, HabitatType,
-    Regulation, Value, Transaction, Person, FeatureValue, TransactionFeature, HabitatTypeObservation)
-from .forms import FeatureForm, HabitatTypeObservationInlineForm
+    Regulation, Value, Transaction,
+    Person, FeatureValue, TransactionFeature,
+    HabitatTypeObservation, Protection,
+)
+from .forms import FeatureForm, HabitatTypeObservationInlineForm, ProtectionInlineForm
 from .widgets import NatureOLWidget
 
 
@@ -94,6 +97,12 @@ class HabitatTypeObservationInline(admin.TabularInline):
     extra = 1
 
 
+class ProtectionInline(admin.StackedInline):
+    model = Protection
+    form = ProtectionInlineForm
+    max_num = 1
+
+
 @admin.register(Feature)
 class FeatureAdmin(admin.GeoModelAdmin):
     readonly_fields = ('_area', 'created_by', 'created_time', 'last_modified_by', 'last_modified_time')
@@ -104,6 +113,7 @@ class FeatureAdmin(admin.GeoModelAdmin):
     inlines = [
         ObservationInline, FeatureLinkInline, FeaturePublicationInline,
         FeatureValueInline, TransactionFeatureInline, HabitatTypeObservationInline,
+        ProtectionInline,
     ]
     actions = None
 
@@ -120,6 +130,16 @@ class FeatureAdmin(admin.GeoModelAdmin):
             obj.created_by = request.user.username
         obj.last_modified_by = request.user.username
         obj.save()
+
+    def get_inline_instances(self, request, obj=None):
+        inline_instances = super().get_inline_instances(request, obj)
+        # We add the protection inline by default, and pop the inline
+        # if there's no object or the object is not protected. This is
+        # because we want the protection inline to go through the
+        # standard permission processing which is done in base class.
+        if not (obj and obj.is_protected):
+            inline_instances.pop()
+        return inline_instances
 
     def get_fields(self, request, obj=None):
         form = self.get_form(request, obj, fields=None)

--- a/nature/forms.py
+++ b/nature/forms.py
@@ -1,7 +1,11 @@
-from django import forms
 from ckeditor.widgets import CKEditorWidget
+from django import forms
+from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.db import transaction
+from django.utils.translation import ugettext_lazy as _
 
-from nature.models import FeatureClass
+from nature.models import FeatureClass, Criterion, ConservationProgramme, Protection, ProtectionCriterion, \
+    ProtectionConservationProgramme
 
 
 class FeatureForm(forms.ModelForm):
@@ -26,3 +30,48 @@ class HabitatTypeObservationInlineForm(forms.ModelForm):
         widgets = {
             'additional_info': forms.Textarea(attrs={'rows': '5'}),
         }
+
+
+class ProtectionInlineForm(forms.ModelForm):
+    criteria = forms.ModelMultipleChoiceField(
+        queryset=Criterion.objects.all(),
+        widget=FilteredSelectMultiple(verbose_name=_('Criteria'), is_stacked=False),
+    )
+    conservation_programmes = forms.ModelMultipleChoiceField(
+        queryset=ConservationProgramme.objects.all(),
+        widget=FilteredSelectMultiple(verbose_name=_('Conservation programmes'), is_stacked=False),
+
+    )
+
+    class Meta:
+        model = Protection
+        fields = '__all__'
+
+    @transaction.atomic
+    def save(self, commit=True):
+        protection = super().save(commit=False)
+        if commit:
+            protection.save()
+
+        if protection.pk:
+            # django does not allow saving m2m with manually specified m2m intermediate
+            # tables, so use intermediate model manager instead.
+            ProtectionCriterion.objects.filter(protection=protection).delete()
+            protection_criteria = [
+                ProtectionCriterion(
+                    protection=protection,
+                    criterion=criterion,
+                ) for criterion in self.cleaned_data['criteria']
+            ]
+            ProtectionCriterion.objects.bulk_create(protection_criteria)
+
+            ProtectionConservationProgramme.objects.filter(protection=protection).delete()
+            protection_conservation_programmes = [
+                ProtectionConservationProgramme(
+                    protection=protection,
+                    conservation_programme=conservation_programme,
+                ) for conservation_programme in self.cleaned_data['conservation_programmes']
+            ]
+            ProtectionConservationProgramme.objects.bulk_create(protection_conservation_programmes)
+
+        return protection

--- a/nature/models.py
+++ b/nature/models.py
@@ -260,6 +260,10 @@ class Feature(AbstractFeature):
     def __str__(self):
         return self.name or 'Feature {0}'.format(self.id)
 
+    @property
+    def is_protected(self):
+        return self.feature_class.is_protected
+
 
 class HistoricalFeature(AbstractFeature):
     feature_class = models.ForeignKey('FeatureClass', models.PROTECT, db_column='luokkatunnus',
@@ -500,6 +504,8 @@ class ProtectedFeatureClassQueryset(models.QuerySet):
 
 
 class FeatureClass(models.Model):
+    PROTECTED_FEATURE_CLASS_ID = 'SK'
+
     id = models.CharField(_('id'), primary_key=True, max_length=10, db_column='tunnus')
     name = models.CharField(_('name'), max_length=50, blank=True, null=True, db_column='nimi')
     additional_info = models.CharField(_('additional info'), max_length=255, blank=True, null=True,
@@ -521,6 +527,10 @@ class FeatureClass(models.Model):
 
     def __str__(self):
         return self.name or 'Feature class {0}'.format(self.id)
+
+    @property
+    def is_protected(self):
+        return self.super_class_id == self.PROTECTED_FEATURE_CLASS_ID
 
 
 class BreedingDegree(models.Model):

--- a/nature/tests/test_forms.py
+++ b/nature/tests/test_forms.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from .factories import FeatureFactory, CriterionFactory, ConservationProgrammeFactory
+from ..forms import ProtectionInlineForm
+
+
+class TestProtectionInlineForm(TestCase):
+
+    def setUp(self):
+        self.feature = FeatureFactory()
+        self.criteria_1 = CriterionFactory()
+        self.criteria_2 = CriterionFactory()
+        self.conservation_programme_1 = ConservationProgrammeFactory()
+        self.conservation_programme_2 = ConservationProgrammeFactory()
+
+    def test_save(self):
+        form_data = {
+            'id': self.feature.id,
+            'reported_area': 'Test reported area',
+            'criteria': [
+                self.criteria_1.id,
+                self.criteria_2.id,
+            ],
+            'conservation_programmes': [
+                self.conservation_programme_1.id,
+                self.conservation_programme_2.id
+            ],
+        }
+        form = ProtectionInlineForm(form_data)
+        self.assertTrue(form.is_valid())
+
+        protection = form.save()
+        self.assertEqual(protection.criteria.count(), 2)
+        self.assertEqual(protection.conservation_programmes.count(), 2)

--- a/nature/tests/test_models.py
+++ b/nature/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch, MagicMock
+
 from django.test import TestCase
 from django.contrib.gis.geos import Point, Polygon
 from django.utils.translation import activate
@@ -178,6 +180,14 @@ class TestFeature(TestCase):
         self.assertEqual(self.feature.area, round_down_area)
         self.assertEqual(self.feature.formatted_area, 57.83)
 
+    def test_feature_is_protected(self):
+        with patch('nature.models.FeatureClass.is_protected', new_callable=MagicMock(return_value=True)):
+            self.assertTrue(self.feature.is_protected)
+
+    def test_feature_is_not_protected(self):
+        with patch('nature.models.FeatureClass.is_protected', new_callable=MagicMock(return_value=False)):
+            self.assertFalse(self.feature.is_protected)
+
 
 class TestHistoricalFeature(TestCase):
 
@@ -303,6 +313,16 @@ class TestFeatureClass(TestCase):
         self.feature_class.id = 123
         self.feature_class.name = None
         self.assertEqual(self.feature_class.__str__(), 'Feature class 123')
+
+    def test_feature_class_is_protected(self):
+        self.feature_class.super_class = FeatureClassFactory(id=FeatureClass.PROTECTED_FEATURE_CLASS_ID)
+        self.assertTrue(self.feature_class.is_protected)
+
+    def test_feature_class_is_not_protected(self):
+        self.assertFalse(self.feature_class.is_protected)
+
+        self.feature_class.super_class = FeatureClassFactory()
+        self.assertFalse(self.feature_class.is_protected)
 
 
 class TestBreedingDegree(TestCase):


### PR DESCRIPTION
This PR added a new stacked inline form for protection fields at the bottom of feature form. A feature must be saved as a protected feature class first in order to edit protection fields.

Refs: #50 

![feature-protection](https://user-images.githubusercontent.com/1997039/41470210-a3d76e80-70b8-11e8-9e5f-9bff06d2aed4.png)


