### PR TITLE
Criterion string should also show specific_criterion and subcriterion when available

### DIFF
--- a/nature/models.py
+++ b/nature/models.py
@@ -696,7 +696,8 @@ class Criterion(models.Model):
         verbose_name_plural = _('cirteria')
 
     def __str__(self):
-        return str(self.criterion)
+        values = [self.criterion, self.specific_criterion, self.subcriterion]
+        return ', '.join([value for value in values if value is not None])
 
 
 class TransactionRegulation(models.Model):

--- a/nature/tests/test_models.py
+++ b/nature/tests/test_models.py
@@ -387,6 +387,12 @@ class TestCriterion(TestCase):
     def test__str__(self):
         self.assertEqual(self.criterion.__str__(), 'criterion')
 
+        self.criterion.subcriterion = 'subcriterion'
+        self.assertEqual(self.criterion.__str__(), 'criterion, subcriterion')
+
+        self.criterion.specific_criterion = 'specific_criterion'
+        self.assertEqual(self.criterion.__str__(), 'criterion, specific_criterion, subcriterion')
+
 
 class TestTransaction(TestCase):
 


### PR DESCRIPTION
Many criterion have same criterion, and it confuses users when selecting criteria for features.

no refs