### PR TITLE
Update models.py

### DIFF
--- a/nature/models.py
+++ b/nature/models.py
@@ -408,7 +408,7 @@ class Species(ProtectionLevelMixin, models.Model):
         ordering = ['id']
         db_table = 'lajirekisteri'
         verbose_name = _('species')
-        verbose_name_plural = _('species')
+        verbose_name_plural = _('species register')
 
     def __str__(self):
         name_list = [self.name_fi, self.name_sci_1, self.name_subspecies_1]


### PR DESCRIPTION
_Species_ is both singular and plural, so in translation file it is not possible to define Finnish _laji_ and _lajit_. I went through the app and it seems that if English plural is changed to "species register", the terms are fine in both languages.  (I will send next update to the translations)