### PR TITLE
Add help texts for form fields

### DIFF
--- a/nature/admin.py
+++ b/nature/admin.py
@@ -9,7 +9,9 @@ from .models import (
     Person, FeatureValue, TransactionFeature,
     HabitatTypeObservation, Protection,
     Square)
-from .forms import FeatureForm, HabitatTypeObservationInlineForm, ProtectionInlineForm, SquareInlineForm
+from .forms import FeatureForm, HabitatTypeObservationInlineForm, ProtectionInlineForm, SquareInlineForm, \
+    ValueForm, ObservationSeriesForm, PersonForm, PublicationForm, FeatureLinkForm, ObservationForm, SpeciesForm, \
+    LinkTypeForm, HabitatTypeForm, RegulationForm, FeatureClassForm, TransactionForm
 from .widgets import NatureOLWidget
 
 
@@ -19,12 +21,14 @@ class SpeciesAdmin(admin.ModelAdmin):
     search_fields = ('name_fi', 'name_sci_1', 'name_subspecies_1', 'code', 'id')
     list_filter = ('taxon', 'taxon_1')
     actions = None
+    form = SpeciesForm
 
 
 @admin.register(ObservationSeries)
 class ObservationSeriesAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'valid')
     search_fields = ('name',)
+    form = ObservationSeriesForm
     actions = None
 
 
@@ -34,6 +38,7 @@ class ObservationInline(admin.TabularInline):
               'protection_level', 'migration_class', 'occurrence', 'origin')
     raw_id_fields = ('species',)
     extra = 1
+    form = ObservationForm
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -44,12 +49,14 @@ class ObservationInline(admin.TabularInline):
 class LinkTypeAdmin(admin.ModelAdmin):
     list_display = ('id', 'name')
     actions = None
+    form = LinkTypeForm
 
 
 class FeatureLinkInline(admin.TabularInline):
     model = FeatureLink
     fields = ('link', 'text', 'link_text', 'link_type', 'ordering', 'protection_level')
     extra = 1
+    form = FeatureLinkForm
 
 
 @admin.register(FeatureClass)
@@ -58,6 +65,7 @@ class FeatureClassAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'www', 'open_data')
     search_fields = ('name',)
     actions = None
+    form = FeatureClassForm
 
 
 @admin.register(Publication)
@@ -66,6 +74,7 @@ class PublicationAdmin(admin.ModelAdmin):
     search_fields = ('name',)
     list_filter = ('publication_type', 'year')
     actions = None
+    form = PublicationForm
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -175,6 +184,7 @@ class HabitatTypeAdmin(admin.ModelAdmin):
     search_fields = ('id', 'name', 'code', 'group', 'lisatieto')
     list_filter = ('group',)
     actions = None
+    form = HabitatTypeForm
 
 
 @admin.register(Regulation)
@@ -183,12 +193,14 @@ class RegulationAdmin(admin.ModelAdmin):
     search_fields = ('id', 'name', 'value', 'value_explanation')
     list_filter = ('valid', 'name')
     actions = None
+    form = RegulationForm
 
 
 @admin.register(Value)
 class ValueAdmin(admin.ModelAdmin):
     list_display = ('id', 'value_type', 'explanation')
     search_fields = ('id', 'value_type', 'explanation')
+    form = ValueForm
     actions = None
 
 
@@ -198,6 +210,7 @@ class TransactionAdmin(admin.ModelAdmin):
     search_fields = ('id', 'description')
     list_filter = ('protection_level', 'transaction_type')
     actions = None
+    form = TransactionForm
 
 
 @admin.register(Person)
@@ -205,3 +218,4 @@ class PersonAdmin(admin.ModelAdmin):
     list_display = ('id', 'surname', 'first_name')
     search_fields = ('id', 'surname', 'first_name')
     actions = None
+    form = PersonForm

--- a/nature/forms.py
+++ b/nature/forms.py
@@ -22,13 +22,36 @@ class FeatureForm(forms.ModelForm):
             'notes': forms.Textarea,
             'name': forms.TextInput(attrs={'size': '80'})
         }
+        help_texts = {
+            'geometry': 'Määrittele paikka kartalle alueena tai pisteinä.<br />'
+                        'Voit luoda erimuotoisia alueita oikeasta ylänurkasta löytyvien geometriatyökalujen avulla. '
+                        '<br />Voit vaihtaa karttapohjan geometriatyökalujen alta löytyvällä painikkeella. <br />'
+                        'Jos olet muokkaamassa kohdetta, valitse "Poista kaikki geometriat" vaihtaaksesi geometriat.',
+            'feature_class': 'Mihin kohdeluokkaan kohde kuuluu',
+            'fid': 'Kohdetunnus, seka kirjaimia että numeroita',
+            'name': 'Kohteen nimi, esim. Harakan etelakarki tai Maununneva. Nimi mieluiten sijaintia kuvaava',
+            'description': 'Kohteen lyhyt kuvaus tai pidempi kuvaileva nimi',
+            'notes': 'Kohteen tietoihin tai geometriaan liittyvää huomionarvoista tietoa',
+            'active': 'Kohde voimassa / ei. oletuksena ”kyllä”',
+            'number': 'Apukentta mm. uusien aineistojen tuontia ja kohteiden erilaisia luokitteluja varten',
+            'text': 'Kohteen kuvausteksti',
+            'text_www': 'Kohteen kuvausteksti, julkinen. Jos kenttä ”teksti_www” on tyhjä,'
+                        'kentän ”teksti” sisältö on julkinen.',
+
+        }
 
 
 class HabitatTypeObservationInlineForm(forms.ModelForm):
-
     class Meta:
         widgets = {
             'additional_info': forms.Textarea(attrs={'rows': '5'}),
+        }
+        help_texts = {
+            'group_fraction': 'Luontotyypin osuus kuviosta prosentteina',
+            'additional_info': 'Muuta tietoa luontotyyppihavainnosta',
+            'observation_series': 'Havaintosarjan id (havaintosarja-taulusta), vierasavain',
+            'created_time': 'Havaintorivin luontihetki, automaattinen',
+            'last_modified_time': 'Havaintorivin editointihetki, automaattinen',
         }
 
 
@@ -80,10 +103,204 @@ class ProtectionInlineForm(forms.ModelForm):
 
 
 class SquareInlineForm(forms.ModelForm):
-
     class Meta:
         model = Square
         fields = '__all__'
         widgets = {
             'additional_info': forms.Textarea(attrs={'rows': '5'}),
+        }
+
+
+class ValueForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'value_type': 'Arvoluokka, esim. 1, 2 ja 3 tai i, ii ja iii',
+            'explanation': 'Kertoo, mitä luokitus tarkoittaa, esim. paikallisesti tai alueellisesti arvokas',
+            'valuator': 'Arvotuksen tekijä',
+            'date': 'Päivämäärä',
+            'link': 'Linkki lisätietoihin',
+        }
+
+
+class ObservationSeriesForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'name': 'Havaintosarjan nimi. Kertoo, mihin tutkimukseen, ajanjaksoon tai ryhmään havainnot kuuluvat',
+            'person': 'Havaintosarjan vastuuhenkilö, henkilo-taulun id',
+            'description': 'Havaintosarjan kuvaus',
+            'start_date': 'Havaintosarjan alkupäivämäärä',
+            'end_date': 'Havaintosarjan loppupäivämääsä',
+            'notes': 'Huomioitavaa, esim. mahdolliset tutkimuksen puuttelliset osat.',
+            'additional_info': 'Lisätieto',
+            'valid': 'Kertoo, onko havaintosarja voimassa vai ei. Oletusarvona ”Kyllä”',
+        }
+
+
+class PersonForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'expertise': 'Henkilön mahdollinen erityisasiantuntemus.',
+            'notes': 'Mahdolliset lisätiedot',
+            'company': 'Yrityksen nimi',
+            'public_servant': 'Tieto onko henkilö viranomainen vai ei',
+            'created_time': 'Ajankohta, jolloin henkillö lisätty rekisteriin. Automaattinen.',
+        }
+
+
+class PublicationForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'name': 'Julkaisun nimi',
+            'author': 'Julkaisun tekijä / tekijät',
+            'series': 'Sarja, jossa julkaistu',
+            'place_of_printing': 'Painopaikka',
+            'year': 'Julkaisuvuosi /julkaisuvuodet',
+            'additional_info': 'Lisätietoa julkaisusta, esim. julkaistu myös ruotsiksi, isbn-numero,',
+            'link': 'Linkki julkaisuun tai siihen liittyvään dokumenttiin',
+        }
+
+
+class FeatureLinkForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'link': 'Linkki esim. kuvaan tai muuhun tiedostoon',
+            'text': 'Linkkiin liittyvä teksti. Esim. kuvan kuvateksti',
+            'link_text': 'Teksti, jona linkki näkyy raportissa esim. ”Kuva 1”',
+            'link_type': 'Linkkityyppi-taulun id, kertoo onko kyseessä kuvalinkki, nettisivulinkki, '
+                         'raporttilinkki jne.',
+            'ordering': 'K.o. linkin sijainti raportoinnissa suhteessa muihin linkkeihin.',
+            'protection_level': 'Suojaustaso 1,2,3',
+        }
+
+
+class ObservationForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'number': 'Havaittujen yksilöiden tai muiden yksiköiden lukumäärä.',
+            'migration_class': 'Liikkumislk-taulun id. Kertoo liikkumisluokan. Arvot 1-3, käytetään vain linnuille '
+                               '(tarvittaessa myös muille eläimille)',
+            'breeding_degree': 'Pesimisvarmuus-taulun id. Kertoo liikkumisluokan. Arvot 1-9, käytetään vain linnuille '
+                               '(tarvittaessa myös muille eläimille)',
+            'description': 'Havaintoon liittyvää kuvailevaa tietoa, esim. havaitun yksilön sukupuoli, havainnon '
+                           'kellonaika, tms.',
+            'notes': 'Tiedot esim. havainnon varmuudesta tai muusta huomionarvoisesta tiedosta',
+            'date': 'Havainnon päivämäärä (ja kellonaika) Tämä ei ole pakollinen kenttä, koska jos lajiin liittyy '
+                    'havaintosarja, päivämäärä tulee havaintosarjasta.',
+            'created_time': 'Havaintorivin luontihetki, automaattinen',
+            'last_modified_time': 'Havainnon editointihetki, automaattinen',
+            'code': 'Havainnon koodi, käytetään tiedonsiirrossa',
+        }
+
+
+class SpeciesForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'taxon': 'Lajin ylin luokittelu ltj:ssä: kasvi /sieni/ eläin',
+            'taxon_1': 'Ryhmää tarkempi luokittelu: mm. levä, putkilokasvi, lintu, nisäkäs, sammakkoeläin, matelija ',
+            'taxon_2': 'Eliöryhmä1:stä tarkempi luokittelu: sinilevä, viherlevä, lepakko, perhonen',
+            'order_fi': 'Lahkon suomenkielinen nimi',
+            'order_la': 'Lahkon tieteellinen nimi',
+            'family_fi': 'Heimon suomenkielinen nimi',
+            'family_la': 'Heimon tieteellinen nimi',
+            'name_fi': 'Lajin / alalajin / muun taksonin suomenkielinen nimi',
+            'name_fi_2': 'Rinnakkainen tai vanha suomenkielinen nimi',
+            'name_sci_1': 'Lajin / alalajin / muun taksonin tieteellinen nimi',
+            'name_sci_2': 'Rinnakkainen tai vanha tieteellinen nimi (tähän kirjataan ex-tieteellinen nimi alalajin '
+                          'kanssa kokonaan, mikäli myös lajinimi vaihtunut)',
+            'name_subspecies_1': 'Alalaji',
+            'name_subspecies_2': 'Rinnakkainen tai vanha alalaji (käytetään kun vain alalajitieto muuttunut, muutoin '
+                                 'kenttä nimi_tiet_2 epäselvyyksien välttämiseksi)',
+            'author_1': 'Lajin / alalajin auktori, lahde ja vuosi. tai kirja, lista tms., jonka nimistöä käytetty '
+                        '(retkeilykasvio,  luontodirektiivin lista tms.) Täytetään ainakin niille lajeille/ryhmille, '
+                        'joiden nimistö on vastikään vaihtunut tai muutoksia on odotettavissa.',
+            'author_2': 'Rinnakkainen tai vanha auktori, lahde ja vuosi. voi olla useita. voi olla viittaus vanhaa '
+                        'nimistöä käyttävään kirjaan/listaan.',
+            'name_abbreviated_1': 'Kasvit: nimilyhenne Metsätähden mukaan. pääosin muotoa 4+4, myös 4+3, 3+4 ja 3+3. '
+                                  'Linnut: tieteellisen nimen mukainen lyhenne.',
+            'name_abbreviated_2': 'Kasvit: nimilyhenne Kurton mukaan. Pääosin muotoa 4+4, myös 4+3, 3+4 ja 3+3. '
+                                  'Linnut: aikaisemman tiet nimen mukainen lyhenne 3+3',
+            'name_sv': 'Ruotsinkielinen nimi',
+            'name_en': 'Englanninkielinen nimi',
+            'registry_date': 'Päivämäärä, jolloin laji lisätty rekisteriin',
+            'protection_level': 'Suojaustaso 3: saa näyttää netissä, 2: vain ylläpitäjät ja virkakäyttäjät, 1: vain '
+                                'ylläpitäjät. Oletusarvo 3.',
+            'additional_info': 'Kertoo esimerkiksi aikaisemmista nimistötiedoista',
+            'code': '2016: lajitietokeskuksen mx-koodi. 0=tarkemmin määrittämättömät',
+            'link': 'Lajiin liittyvän sivun/kuvan tms. linkki',
+        }
+
+
+class LinkTypeForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'name': 'Kuvalinkki, pdf-tiedosto jne.',
+        }
+
+
+class HabitatTypeForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'name': 'Luontotyypin nimi. Luontotyypeillä voi olla sama nimi, jos luontotyyppiryhmä on eri.',
+            'code': 'Luontotyypin koodi. Luontotyypeillä voi olla sama koodi, jos  luontotyyppiryhmä on eri.',
+            'description': 'Luontotyypin kuvaus',
+            'additional_info': 'Tähän kirjataan lisätieto, esim. jos kyseessä on EU:n ensisijainen luontotyyppi.',
+            'group': 'Kertoo mihin ryhmään luontotyyppi kuuluu, esim. luontodirektiivin luontotyypit',
+        }
+
+
+class FeatureClassForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'name': 'Luokan nimi',
+            'additional_info': 'Luokan lisätieto',
+            'super_class': 'Pääluokkia ovat suojelukohde ja ruutukohde.K.o. pääkohteeseen kuuluvilla luokilla on '
+                           'lisätietoja, jota muilla luokilla ei ole.',
+            'reporting': 'Kyllä/Ei-merkintä, jonka mukaisesti luokan kohteet ovat mukana esim. kohderaportoinnissa '
+                         'ja hakutoiminnoissa. Oletusarvona ”Kyllä”',
+            'www': 'Kyllä/Ei-merkintä, jonka mukaisesti luokka näytetään yleisöversiossa tai ei näytetä.',
+            'open_data': 'Kyllä/Ei-merkintä, jonka mukaisesti luokka (luokan kohteet havaintoineen) näytetään '
+                         'rajapinnassa avoimena datana tai ei näytetä.',
+            'metadata': 'Linkki aineistokuvaukseen',
+        }
+
+
+class RegulationForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'name': 'Asetuksen tms. nimi',
+            'paragraph': 'Pykälä tai liite',
+            'additional_info': 'Vapaamuotoinen tekstikenttä',
+            'value': 'Esim. IUCN-luokka (NT, RT jne.)',
+            'value_explanation': 'Arvo-kentässä olevan lyhenteen selite',
+            'valid': 'Voimassaolo. Oletuksena ”kyllä”',
+            'date_of_entry': 'Säädöksen tms. virallinen voimaantulopvm.',
+            'link': 'Linkki säädökseen tai säädöskokoelmaan',
+        }
+
+
+class ProtectionForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'reported_area': 'Suojelupäätöksessä oleva kokonaispinta-ala',
+            'land_area': 'Maapinta-ala',
+            'water_area': 'Vesipinta-ala',
+            'hiking': 'Liikkumisrajoitukset',
+            'regulations': 'Muut määräykset',
+            'additional_info': 'Lisätieto'
+        }
+
+
+class TransactionForm(forms.ModelForm):
+    class Meta:
+        help_texts = {
+            'register_id': 'Asiakirjojen diaarinro',
+            'description': 'Tapahtuman kuvaus',
+            'transaction_type': 'tapahtumatyyppi-taulun id, vierasavain. kertoo onko tapahtuma esim. päätös tai '
+                                'tutkimus',
+            'last_modified_by': 'Tapahtumaan liittyvien tietojen päivittäjä',
+            'date': 'Tapahtuman päivämäärä',
+            'person': 'Henkilo-taulun id, vierasavain. Tapahtuman tekija, jos henkilö',
+            'link': 'Linkki tapahtumaa koskevaan dokumenttiin',
+            'protection_level': 'Suojaustaso 3: saa näyttää netissä, 2: vain ylläpitäjät ja virkakäyttäjät, 1: vain '
+                                'ylläpitäjät. Oletusarvo 3.',
         }


### PR DESCRIPTION
The texts are not using `ugettext_lazy` on purpose as there is no plan
on translating these fields to English.

Refs: https://github.com/City-of-Helsinki/ltj/issues/52