### PR TITLE
Add wfs layers to feature editing map

### DIFF
--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -18,6 +18,8 @@ env = environ.Env(
     LOG_LEVEL=(str, 'INFO'),
     SENTRY_DSN=(str, ''),
     SENTRY_ENVIRONMENT=(str, 'unconfigured'),
+    WFS_SERVER_URL=(str, 'http://localhost/'),
+    WFS_NAMESPACE=(str, 'ltj-dev'),
 )
 
 # .env file, should load only in development environment
@@ -156,3 +158,6 @@ USE_TZ = True
 # Custom settings
 
 SRID = 3879  # Spatial reference system identifier used for geometry fields
+
+WFS_SERVER_URL = env('WFS_SERVER_URL')  # WFS server url for features
+WFS_NAMESPACE = env('WFS_NAMESPACE')  # Namespace for WFS layers

--- a/nature/templates/nature/openlayers-nature.html
+++ b/nature/templates/nature/openlayers-nature.html
@@ -23,7 +23,8 @@
             name: '{{ name }}',
             default_x: {{ default_x|unlocalize }},
             default_y: {{ default_y|unlocalize }},
-            default_zoom: {{ default_zoom|unlocalize }}
+            default_zoom: {{ default_zoom|unlocalize }},
+            wfs_server_url: '{% url 'nature:wfs' %}'
         };
         {% endblock %}
         var {{ module }} = new MapWidget(options);

--- a/nature/tests/test_views.py
+++ b/nature/tests/test_views.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock, patch
+
+from django.http import QueryDict
+from django.test import TestCase, RequestFactory, override_settings
+from django.urls import reverse
+
+from nature.tests.factories import FeatureClassFactory
+from nature.tests.utils import make_user
+from ..views import FeatureWFSView
+
+
+class MockResponse:
+
+    def __init__(self, content, content_type, status_code):
+        self.content = content
+        self.status_code = status_code
+        self.headers = {'content-type': content_type}
+
+
+@patch('requests.get', MagicMock(side_effect=lambda url: MockResponse(b'abc', 'application/xml', 400)))
+class TestFeatureWFSView(TestCase):
+
+    @property
+    def test_wfs_url(self):
+        query_dict = QueryDict(mutable=True)
+        query_dict.update({
+            'service': 'WFS',
+            'version': '1.1.0',
+            'typeName': 'test-feature',
+            'outputFormat': 'application/json',
+            'srsname': 'EPSG:3879',
+            'bbox': '0,1,2,3,EPSG:3879'
+        })
+        return '{0}?{1}'.format(reverse('nature:wfs'), query_dict.urlencode())
+
+    def setUp(self):
+        self.user = make_user()
+        self.view = FeatureWFSView()
+        factory = RequestFactory()
+        self.request = factory.get(self.test_wfs_url)
+        self.view.request = self.request
+
+    def test_get(self):
+        response = self.view.get(self.request)
+        self.assertEqual(response.content, b'abc')
+        self.assertEqual(response['Content-Type'], 'application/xml')
+        self.assertEqual(response.status_code, 400)
+
+    @override_settings(
+        WFS_SERVER_URL='http://testserver/',
+        WFS_NAMESPACE='test-namespace',
+    )
+    def test_get_wfs_url(self):
+        FeatureClassFactory(id='FC-ID-1')
+        FeatureClassFactory(id='FC-ID-2')
+
+        wfs_url = self.view._get_wfs_url()
+        server_url, query_string = wfs_url.split('?')
+        self.assertEqual(server_url, 'http://testserver/')
+
+        query_dict = QueryDict(query_string)
+        expected_dict = {
+            'service': 'WFS',
+            'version': '1.1.0',
+            'typeName': 'test-namespace:test-feature',
+            'outputFormat': 'application/json',
+            'srsname': 'EPSG:3879',
+            'bbox': '0,1,2,3,EPSG:3879'
+        }
+        self.assertEqual(query_dict.dict(), expected_dict)

--- a/nature/urls.py
+++ b/nature/urls.py
@@ -5,4 +5,5 @@ from . import views
 app_name = 'nature'
 urlpatterns = [
     url(r'^feature-report/(?P<pk>\d+)/$', views.FeatureReportView.as_view(), name='feature-report'),
+    url(r'^wfs', views.FeatureWFSView.as_view(), name='wfs'),
 ]

--- a/nature/views.py
+++ b/nature/views.py
@@ -1,4 +1,10 @@
+import requests
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse
+from django.utils.decorators import method_decorator
 from django.views.generic import DetailView
+from django.views import View
 
 from .models import Feature
 
@@ -6,3 +12,24 @@ from .models import Feature
 class FeatureReportView(DetailView):
     queryset = Feature.objects.open_data()
     template_name = 'nature/feature-report.html'
+
+
+@method_decorator(login_required, name='dispatch')
+class FeatureWFSView(View):
+
+    def get(self, request, *args, **kwargs):
+        url = self._get_wfs_url()
+        r = requests.get(url)
+        return HttpResponse(
+            content=r.content,
+            content_type=r.headers['content-type'],
+            status=r.status_code,
+        )
+
+    def _get_wfs_url(self):
+        query_dict = self.request.GET.copy()
+        query_dict.setlist('typeName', [self._get_layer_typename()])
+        return '{0}?{1}'.format(settings.WFS_SERVER_URL, query_dict.urlencode())
+
+    def _get_layer_typename(self):
+        return '{0}:{1}'.format(settings.WFS_NAMESPACE, self.request.GET.get('typeName'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ traitlets==4.3.2
 wcwidth==0.1.7
 raven==6.9.0
 pyshp==1.2.12
+requests==2.18.4


### PR DESCRIPTION
This PR adds the feature wfs layers to feature editing map. The layers are separated by each feature classes, and the wfs layers are created from database views.

The WFS resources comes from remote WFS server and the django application serves as proxy for it. The main reason is that we need to keep the WFS resource private and make it available to authenticated users. This also makes it possible to do fine-grained access control for different type of users when needed. 

Currently WFS layers are rendered in Red-Green color scales and the target feature is rendered as blue to distinguish from the WFS features.

Deployment notes:
- Two setting variables are added which can be set form environment variables
    **WFS_SERVER_URL** - remote wfs server url that the app can download wfs resources, the url should include credentials if required, e.g: https://username:password@example.com/geoserver/wfs
    **WFS_NAMESPACE** - the namespace for the wfs layers
- The layer names should be fixed and identical between different namespaces.

Refs: #39 

![wfs-layers](https://user-images.githubusercontent.com/1997039/42384284-435d57e6-8142-11e8-88a5-d92e18d9389a.gif)
