### PR TITLE
Turn off all WFS layers by default

### DIFF
--- a/nature/static/nature/js/NatureOLMapWidget.js
+++ b/nature/static/nature/js/NatureOLMapWidget.js
@@ -329,6 +329,7 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
             return new ol.layer.Vector({
                 type: 'feature-wfs',
                 title: wfsLayer[1],
+                visible: false,
                 source: new ol.source.Vector({
                     format: new ol.format.GeoJSON(),
                     url: function(extent) {


### PR DESCRIPTION
Normally user want to turn on the layers that has the same feature class as the feature being updated