### PR TITLE
Add report links to Species admin list display and change form

### DIFF
--- a/nature/admin.py
+++ b/nature/admin.py
@@ -18,11 +18,18 @@ from .widgets import NatureOLWidget
 
 @admin.register(Species)
 class SpeciesAdmin(admin.ModelAdmin):
-    list_display = ('id', 'name_fi', 'name_sci_1', 'name_subspecies_1', 'code')
+    list_display = ('id', 'name_fi', 'name_sci_1', 'name_subspecies_1', 'code', 'report')
     search_fields = ('name_fi', 'name_sci_1', 'name_subspecies_1', 'code', 'id')
     list_filter = ('taxon', 'taxon_1')
     actions = None
     form = SpeciesForm
+    change_form_template = 'admin/species.html'
+
+    def report(self, obj):
+        url = reverse('nature:species-report', kwargs={'pk': obj.id})
+        return '<a target="_blank" href="{0}">{1}</a>'.format(url, _('Species report'))
+    report.allow_tags = True
+    report.short_description = _('Species report')
 
 
 @admin.register(ObservationSeries)

--- a/nature/templates/admin/species.html
+++ b/nature/templates/admin/species.html
@@ -1,0 +1,7 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    <li><a target="_blank" href="{% url 'nature:species-report' pk=object_id %}">{% trans "Species report" %}</a></li>
+    {{ block.super }}
+{% endblock %}

--- a/nature/tests/test_admin.py
+++ b/nature/tests/test_admin.py
@@ -4,10 +4,28 @@ from django.contrib.admin.sites import AdminSite
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
 
-from .factories import FeatureFactory, ObservationFactory, PublicationFactory
+from .factories import FeatureFactory, ObservationFactory, PublicationFactory, SpeciesFactory
 from .utils import make_user
-from ..admin import FeatureAdmin, ObservationInline, PublicationAdmin, ProtectionInline, SquareInline
-from ..models import Feature, Publication
+from ..admin import FeatureAdmin, ObservationInline, PublicationAdmin, ProtectionInline, SquareInline, SpeciesAdmin
+from ..models import Feature, Publication, Species
+
+
+class TestSpeciesAdmin(TestCase):
+
+    def setUp(self):
+        self.user = make_user()
+        self.species = SpeciesFactory()
+        self.site = AdminSite()
+        self.factory = RequestFactory()
+
+    def test_report(self):
+        fa = SpeciesAdmin(Species, self.site)
+        request = self.factory.get('/fake-url/')
+        request.user = self.user
+
+        report = fa.report(self.species)
+        url = reverse('nature:species-report', kwargs={'pk': self.species.id})
+        self.assertIn(url, report)
 
 
 class TestObservationInline(TestCase):


### PR DESCRIPTION
Species admin list display view:
![species-report-urls](https://user-images.githubusercontent.com/1997039/43003485-5424fdf6-8c35-11e8-9873-1c236f14737a.png)

Species admin change form view:
![species-change-form-report-url](https://user-images.githubusercontent.com/1997039/43003496-626f5834-8c35-11e8-974f-d111d11c499d.png)


