### PR TITLE
Change to use user role instead of object protection level in report title

### DIFF
--- a/nature/templates/nature/reports/feature-habitattypeobservations-report.html
+++ b/nature/templates/nature/reports/feature-habitattypeobservations-report.html
@@ -1,7 +1,7 @@
 {% extends 'nature/reports/report-base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "Feature Report - Habitat Type Observations" %} - {{ feature.get_protection_level_display }}{% endblock %}
+{% block title %}{% trans "Feature Report - Habitat Type Observations" %} - {{ user_role }}{% endblock %}
 
 {% block extrastyles %}
     <style>

--- a/nature/templates/nature/reports/feature-observations-report.html
+++ b/nature/templates/nature/reports/feature-observations-report.html
@@ -1,7 +1,7 @@
 {% extends 'nature/reports/report-base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "Feature Report - Observations" %} - {{ feature.get_protection_level_display }}{% endblock %}
+{% block title %}{% trans "Feature Report - Observations" %} - {{ user_role }}{% endblock %}
 
 {% block extrastyles %}
     <style>

--- a/nature/templates/nature/reports/feature-report.html
+++ b/nature/templates/nature/reports/feature-report.html
@@ -1,7 +1,7 @@
 {% extends "nature/reports/report-base.html" %}
 {% load i18n static %}
 
-{% block title %}{% trans "Feature Report" %} - {{ feature.get_protection_level_display }}{% endblock %}
+{% block title %}{% trans "Feature Report" %} - {{ user_role }}{% endblock %}
 
 {% block extrastyles %}
     <link href="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.css" type="text/css" media="all" rel="stylesheet">

--- a/nature/templates/nature/reports/observation-report.html
+++ b/nature/templates/nature/reports/observation-report.html
@@ -1,7 +1,7 @@
 {% extends "nature/reports/report-base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Observation Report" %} - {{ observation.get_protection_level_display }}{% endblock %}
+{% block title %}{% trans "Observation Report" %} - {{ user_role }}{% endblock %}
 
 {% block report_header %}{% trans "Observation" %}{% endblock %}
 

--- a/nature/templates/nature/reports/species-regulations-report.html
+++ b/nature/templates/nature/reports/species-regulations-report.html
@@ -1,7 +1,7 @@
 {% extends "nature/reports/report-base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Species Regulations Report" %} - {{ species.get_protection_level_display }}{% endblock %}
+{% block title %}{% trans "Species Regulations Report" %} - {{ user_role }}{% endblock %}
 
 {% block extrastyles %}
     <style>

--- a/nature/tests/test_views.py
+++ b/nature/tests/test_views.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from django.http import QueryDict
 from django.test import Client, TestCase, RequestFactory, override_settings
 from django.urls import reverse
+from django.utils.translation import activate
 from freezegun import freeze_time
 
 from nature.models import PROTECTION_LEVELS, OFFICE_HKI_ONLY_FEATURE_CLASS_ID
@@ -19,6 +20,7 @@ from ..views import FeatureWFSView, SpeciesReportView, FeatureObservationsReport
 class TestFeatureReportHMACAuth(TestCase):
 
     def setUp(self):
+        activate('fi')
         feature_class_office_hki = FeatureClassFactory(id=OFFICE_HKI_ONLY_FEATURE_CLASS_ID)
         self.feature_admin = FeatureFactory(protection_level=PROTECTION_LEVELS['ADMIN'])
         self.feature_office_hki = FeatureFactory(
@@ -47,18 +49,22 @@ class TestFeatureReportHMACAuth(TestCase):
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_admin.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Admin</title>'.encode('utf-8'), response.content)
 
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_office_hki.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Admin</title>'.encode('utf-8'), response.content)
 
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_office.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Admin</title>'.encode('utf-8'), response.content)
 
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_public.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Admin</title>'.encode('utf-8'), response.content)
 
     @freeze_time('2019-01-17 12:00:00')
     def test_hmac_office_hki_group_can_access_non_admin_reports(self):
@@ -83,14 +89,17 @@ class TestFeatureReportHMACAuth(TestCase):
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_office_hki.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Virka Hki</title>'.encode('utf-8'), response.content)
 
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_office.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Virka Hki</title>'.encode('utf-8'), response.content)
 
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_public.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Virka Hki</title>'.encode('utf-8'), response.content)
 
     @freeze_time('2019-01-17 12:00:00')
     def test_hmac_office_group_can_access_office_and_public_reports(self):
@@ -119,10 +128,12 @@ class TestFeatureReportHMACAuth(TestCase):
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_office.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Virka</title>'.encode('utf-8'), response.content)
 
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_public.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Virka</title>'.encode('utf-8'), response.content)
 
     @freeze_time('2019-01-17 12:00:00')
     def test_hmac_unauthorized_group_can_access_public_reports(self):
@@ -155,6 +166,7 @@ class TestFeatureReportHMACAuth(TestCase):
         url = reverse('nature:feature-report', kwargs={'pk': self.feature_public.id})
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+        self.assertIn('<title>Kohderaportti - Yleisö</title>'.encode('utf-8'), response.content)
 
 
 class TestProtectedReportViewMixin(TestCase):

--- a/nature/views.py
+++ b/nature/views.py
@@ -5,6 +5,7 @@ from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView
 from django.views import View
+from django.utils.translation import ugettext as _
 
 from nature.hmac import HMACAuth
 from .models import Feature, Species, ObservationSeries, Observation
@@ -22,7 +23,7 @@ class ProtectedReportViewMixin:
         if self.request.user.is_staff:
             return qs
 
-        hmac_auth = HMACAuth(self.request)
+        hmac_auth = self._get_hmac_auth()
         if hmac_auth.has_admin_group:
             return qs.for_admin()
         elif hmac_auth.has_office_hki_group:
@@ -31,6 +32,27 @@ class ProtectedReportViewMixin:
             return qs.for_office()
 
         return qs.www()
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+
+        hmac_auth = self._get_hmac_auth()
+        if self.request.user.is_staff or hmac_auth.has_admin_group:
+            user_role = _('Admin')
+        elif hmac_auth.has_office_hki_group:
+            user_role = _('Office Hki')
+        elif hmac_auth.has_office_group:
+            user_role = _('Office')
+        else:
+            user_role = _('Public')
+        context_data['user_role'] = user_role
+
+        return context_data
+
+    def _get_hmac_auth(self):
+        if not hasattr(self, '_hmac_auth'):
+            self._hmac_auth = HMACAuth(self.request)
+        return self._hmac_auth
 
 
 class FeatureReportView(ProtectedReportViewMixin, DetailView):


### PR DESCRIPTION
Previously all reports are using the target object's protection level as a suffix in the title, this should be changed to use the current user role.