### PR TITLE
Remove taxon_2 field from species report

### DIFF
--- a/nature/templates/nature/reports/species-report.html
+++ b/nature/templates/nature/reports/species-report.html
@@ -42,11 +42,6 @@
                 <br/>
                 {{ species.taxon_1 | lower | capfirst }}
             {% endif %}
-
-            {% if species.taxon_2 %}
-                <br/>
-                {{ species.taxon_2 | lower | capfirst }}
-            {% endif %}
         </div>
     </div>
     {% if species.link %}


### PR DESCRIPTION
Closes #174 

Remove `taxon_2` field from `species_report.html` template.