### PR TITLE
Change translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -103,7 +103,7 @@ msgid "Feature transactions"
 msgstr "Tapahtumat"
 
 msgid "protection"
-msgstr "suojaus"
+msgstr "suojelukohde"
 
 msgid "square"
 msgstr "ruutu"
@@ -124,7 +124,7 @@ msgid "Public"
 msgstr "Yleisö"
 
 msgid "Criteria"
-msgstr "Perusteet"
+msgstr "Suojeluperusteet"
 
 msgid "Conservation programmes"
 msgstr "Suojeluohjelmat"
@@ -517,7 +517,7 @@ msgid "hiking"
 msgstr "liikkuminen"
 
 msgid "criteria"
-msgstr "perusteet"
+msgstr "suojeluperusteet"
 
 msgid "protections"
 msgstr "suojelu"

--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -97,6 +97,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
 ]
 
 ROOT_URLCONF = 'ltj.urls'

--- a/nature/forms.py
+++ b/nature/forms.py
@@ -61,11 +61,13 @@ class HabitatTypeObservationInlineForm(forms.ModelForm):
 
 class ProtectionInlineForm(forms.ModelForm):
     criteria = forms.ModelMultipleChoiceField(
+        label=_('Criteria'),
         queryset=Criterion.objects.all(),
         widget=FilteredSelectMultiple(verbose_name=_('Criteria'), is_stacked=False),
         required=False,
     )
     conservation_programmes = forms.ModelMultipleChoiceField(
+        label=_('Conservation programmes'),
         queryset=ConservationProgramme.objects.all(),
         widget=FilteredSelectMultiple(verbose_name=_('Conservation programmes'), is_stacked=False),
         required=False,


### PR DESCRIPTION
Closes #154 

Changed the translations according to issue. Problem was that fields mentioned in issue were actually Django forms, so they don't respect `verbose_name`, but `label` instead.