### PR TITLE
Upgrade Django to newest LTS 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 appdirs==1.4.3
 appnope==0.1.0
 decorator==4.3.0
-Django==2.1.7
+Django==2.2
 djangorestframework==3.8.0
 djangorestframework-gis==0.14
 django-ckeditor==5.6.1


### PR DESCRIPTION
Closes #228 

Upgraded Django to newest LTS version 2.2.

Tests seem to pass as expected, and I could not produce any errors with manual testing.