### PR TITLE
Remove unnecessary prefetches from for_office queryset

### DIFF
--- a/nature/models.py
+++ b/nature/models.py
@@ -96,17 +96,14 @@ class FeatureQuerySet(ProtectionLevelQuerySet):
         """ For office users that do not work for City of Helsinki
 
         These users do not have access to UHEX features
+
+        for_office() gets it's prefetch from for_office_hki()
         """
-        transactions = Transaction.objects.filter(protection_level__gte=PROTECTION_LEVELS['OFFICE'])
-        links = FeatureLink.objects.filter(protection_level__gte=PROTECTION_LEVELS['OFFICE'])
-        prefetch_transactions = Prefetch('transactions', queryset=transactions)
-        prefetch_links = Prefetch('links', queryset=links)
         feature_class_id = OFFICE_HKI_ONLY_FEATURE_CLASS_ID
         return (
             super()
             .for_office()
             .exclude(feature_class_id=feature_class_id)
-            .prefetch_related(prefetch_transactions, prefetch_links)
         )
 
     def for_public(self):

--- a/nature/tests/factories.py
+++ b/nature/tests/factories.py
@@ -83,9 +83,22 @@ class FeatureFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('text', max_nb_chars=80)
     active = True
     protection_level = PROTECTION_LEVELS['PUBLIC']
+    links = factory.RelatedFactory('nature.tests.factories.FeatureLinkFactory', 'feature')
 
     class Meta:
         model = 'nature.Feature'
+
+    @factory.post_generation
+    def transactions(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            for transaction in extracted:
+                transaction.features.add(self)
+        else:
+            transaction = TransactionFactory()
+            transaction.features.add(self)
 
 
 class HistoricalFeatureFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Closes #249 

Removed unnecessary (duplicate) prefetches from `FeatureQuerySet`'s `for_office()` method. It turned out, `for_office()` method already got prefetches from `for_office_hki()` through super class.

Added links and transactions to test factories, so a bug like this would be caught in the future.