### PR TITLE
Species report filtering

### DIFF
--- a/nature/templates/nature/reports/species-regulations-report.html
+++ b/nature/templates/nature/reports/species-regulations-report.html
@@ -24,12 +24,12 @@
         <b class="col-sm-2">{% trans "Species" %}</b>
         <div class="col-sm-10">
             {{ species.name_fi | lower | capfirst }}
-            <br/>
             {% if species.name_sci_1 %}
-                <i>{{ species.name_sci_1 | lower | capfirst }}</i>
                 <br/>
+                <i>{{ species.name_sci_1 | lower | capfirst }}</i>
             {% endif %}
             {% if species.name_subspecies_1 %}
+                <br/>
                 <i>{{ species.name_subspecies_1 | lower | capfirst }}</i>
             {% endif %}
         </div>

--- a/nature/templates/nature/reports/species-regulations-report.html
+++ b/nature/templates/nature/reports/species-regulations-report.html
@@ -27,8 +27,8 @@
             <br/>
             {% if species.name_sci_1 %}
                 <i>{{ species.name_sci_1 | lower | capfirst }}</i>
+                <br/>
             {% endif %}
-            <br/>
             {% if species.name_subspecies_1 %}
                 <i>{{ species.name_subspecies_1 | lower | capfirst }}</i>
             {% endif %}

--- a/nature/templates/nature/reports/species-regulations-report.html
+++ b/nature/templates/nature/reports/species-regulations-report.html
@@ -34,11 +34,11 @@
     <hr class="mb-4">
 
     <!-- Regulations -->
-    {% if species.regulations.all %}
+    {% if regulations %}
         <h4 class="text-uppercase">{% trans "Regulations" %}</h4>
         <hr class="mb-2">
 
-        {% for regulation in regulations.all %}
+        {% for regulation in regulations %}
                 {% include 'nature/reports/stubs/species-regulation.html' with regulation=regulation %}
                 {% if not forloop.last %}
                     <hr class="mb-2 dashed">

--- a/nature/templates/nature/reports/species-regulations-report.html
+++ b/nature/templates/nature/reports/species-regulations-report.html
@@ -25,9 +25,13 @@
         <div class="col-sm-10">
             {{ species.name_fi | lower | capfirst }}
             <br/>
-            <i>{{ species.name_sci_1 | lower | capfirst }}</i>
+            {% if species.name_sci_1 %}
+                <i>{{ species.name_sci_1 | lower | capfirst }}</i>
+            {% endif %}
             <br/>
-            <i>{{ species.name_subspecies_1 | lower | capfirst }}</i>
+            {% if species.name_subspecies_1 %}
+                <i>{{ species.name_subspecies_1 | lower | capfirst }}</i>
+            {% endif %}
         </div>
     </div>
 

--- a/nature/templates/nature/reports/species-report.html
+++ b/nature/templates/nature/reports/species-report.html
@@ -51,7 +51,7 @@
         <div class="row">
             <div class="col-sm-2"></div>
             <div class="col-sm-10">
-                <a target="_blank" href="{{ species.link }}">{% trans "Link" %}</a>
+                <a target="_blank" rel="noopener noreferrer" href="{{ species.link }}">{% trans "Link" %}a>
             </div>
         </div>
     {% endif %}
@@ -62,7 +62,7 @@
         <h4 class="text-uppercase">
             {% trans "Regulations" %}
             <small>
-                <a href="{% url 'nature:species-regulations-report' species.id %}">
+                <a  href="{% url 'nature:species-regulations-report' species.id %}">
                     {% trans "Link" %}
                 </a>
             </small>

--- a/nature/templates/nature/reports/species-report.html
+++ b/nature/templates/nature/reports/species-report.html
@@ -58,7 +58,7 @@
     <hr class="mb-4">
 
     <!-- Regulations -->
-    {% if species.regulations.all %}
+    {% if regulations %}
         <h4 class="text-uppercase">
             {% trans "Regulations" %}
             <small>
@@ -69,7 +69,7 @@
         </h4>
         <hr class="mb-2">
 
-        {% for regulation in species.regulations.all %}
+        {% for regulation in regulations %}
             {% include 'nature/reports/stubs/species-regulation.html' with regulation=regulation %}
             {% if not forloop.last %}
                 <hr class="mb-2 dashed">

--- a/nature/templates/nature/reports/species-report.html
+++ b/nature/templates/nature/reports/species-report.html
@@ -62,7 +62,7 @@
         <h4 class="text-uppercase">
             {% trans "Regulations" %}
             <small>
-                <a  href="{% url 'nature:species-regulations-report' species.id %}">
+                <a href="{% url 'nature:species-regulations-report' species.id %}">
                     {% trans "Link" %}
                 </a>
             </small>

--- a/nature/templates/nature/reports/stubs/species-regulation.html
+++ b/nature/templates/nature/reports/stubs/species-regulation.html
@@ -16,7 +16,7 @@
 <div class="row">
     <b class="col-sm-2">{% trans "link"|title %}</b>
     <div class="col-sm-10">
-        <a href="{{ regulation.link | safe }}">{% trans "link"|title %}</a>
+        <a target="_blank" rel="noopener noreferrer" href="{{ regulation.link | safe }}">{% trans "link"|title %}</a>
     </div>
 </div>
 {% endif %}

--- a/nature/views.py
+++ b/nature/views.py
@@ -114,12 +114,15 @@ class ObservationReportView(ProtectedReportViewMixin, DetailView):
     template_name = 'nature/reports/observation-report.html'
 
 
-class SpeciesReportView(ProtectedObservationListReportViewMixin, DetailView):
+class SpeciesReportView(ProtectedObservationListReportViewMixin, ValidRegulationsViewMixin, DetailView):
     queryset = Species.objects.all()
     template_name = 'nature/reports/species-report.html'
 
     def get_observation_queryset(self):
         return self.object.observations.all().order_by('feature__feature_class__name')
+
+    def get_regulations_queryset(self):
+        return self.object.regulations.all()
 
 
 class SpeciesRegulationsReportView(ValidRegulationsViewMixin, DetailView):
@@ -127,7 +130,7 @@ class SpeciesRegulationsReportView(ValidRegulationsViewMixin, DetailView):
     template_name = 'nature/reports/species-regulations-report.html'
 
     def get_regulations_queryset(self):
-        return self.object.regulations
+        return self.object.regulations.all()
 
 
 class ObservationSeriesReportView(DetailView):


### PR DESCRIPTION
Closes #248 

- Filter out invalid regulations
- Make regulation links open in a new tab
- Do not display None values in template 