### PR TITLE
Upgrade django to 2.2.7 LTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 appdirs==1.4.3
 appnope==0.1.0
 decorator==4.3.0
-Django==2.2
+Django==2.2.7
 djangorestframework==3.8.0
 djangorestframework-gis==0.14
 django-ckeditor==5.6.1


### PR DESCRIPTION
Closes #255 

Upgraded Django version to 2.2.7 in `requirements.txt`. 