### PR TITLE
Handle invalid HMAC authentication and raise exceptions

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,7 @@
+{% spaceless %}
+{% if exception %}
+    {{ exception }}
+{% else %}
+    <h1>403 Forbidden</h1>
+{% endif %}
+{% endspaceless %}


### PR DESCRIPTION
Raise 403 with message "Invalid Authorization" exceptions during HMAC-authorization in following cases:

- Hash supplied by the client is wrong
- Time given by the client is not within the clock skew