### PR TITLE
Adjust hr elements

### DIFF
--- a/nature/templates/nature/reports/feature-report.html
+++ b/nature/templates/nature/reports/feature-report.html
@@ -78,7 +78,7 @@
         <hr class="mb-2">
     {% endif %}
 
-    {% if feature.links %}
+    {% if feature.links.all %}
     <div class="mb-5">
         {% for link in feature.links.all|dictsort:"ordering" %}
             <a target="_blank" rel="noopener noreferrer" href="{{ link.link }}">{{ link.link_text }}</a> - {{ link.text }}<br/>

--- a/nature/templates/nature/reports/report-base.html
+++ b/nature/templates/nature/reports/report-base.html
@@ -11,7 +11,6 @@
     <h2 class="text-uppercase">{% block report_header %}{% endblock %}</h2>
     <hr class="mb-2">
     {% block report_body %}{% endblock %}
-    <hr class="mb-4">
     <footer>
         {% block report_footer %}
             <p class="mb-1">Helsingin kaupunki</p>


### PR DESCRIPTION
Closes #274 

- Remove unnecessary hr element from footer
- Call for queryset instead of model manager in template's if-clause, to avoid rendering extra hr element when queryset returns no results