### PR TITLE
Display correct text fields for each user type

### DIFF
--- a/nature/templates/nature/reports/feature-report.html
+++ b/nature/templates/nature/reports/feature-report.html
@@ -74,7 +74,13 @@
     {% if feature.description or feature.text_display %}
         <h4 class="text-uppercase">{% trans "Feature description" %}</h4>
         <p>{{ feature.description|default_if_none:"" }}</p>
-        <p>{{ feature.text_display|default_if_none:""|safe }}</p>
+        {% if not feature.www_text %}
+            <p>{{ feature.text|default_if_none:""|safe }}</p>
+        {% elif user_is_in_admin_groups %}
+            <p>{{ feature.text|default_if_none:""|safe }}</p>
+        {% else %}
+            <p>{{ feature.text_www|default_if_none:""|safe }}</p>
+        {% endif %}
         <hr class="mb-2">
     {% endif %}
 

--- a/nature/views.py
+++ b/nature/views.py
@@ -38,7 +38,9 @@ class ProtectedReportViewMixin:
 
         hmac_auth = self._get_hmac_auth()
         user_role = UserRole.ADMIN if self.request.user.is_staff else hmac_auth.user_role
+        user_is_in_admin_groups = hmac_auth.user_role in [UserRole.ADMIN, UserRole.OFFICE_HKI, UserRole.OFFICE]
         context_data['user_role'] = user_role.value
+        context_data['user_is_in_admin_groups'] = user_is_in_admin_groups
 
         return context_data
 


### PR DESCRIPTION
Closes #277 

Display correct text fields for each user groups. Template logic was split into separate clauses (instead of `or`) for clarity.