### PR TITLE
Fix the social_django path

### DIFF
--- a/ltj/urls.py
+++ b/ltj/urls.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from nature.api import router
 
 urlpatterns = [
-    path("pysocial/", include("social_django.urls", namespace="social")),
+    path("auth/", include("social_django.urls", namespace="social")),
     path("helauth/", include("helusers.urls")),
     path("admin/", admin.site.urls),
     path("v1/", include(router.urls)),


### PR DESCRIPTION
The original path was copied from the `django-helusers` [documentation](https://github.com/City-of-Helsinki/django-helusers#adding-tunnistamo-authentication), which does not work.

Refs: #237