### PR TITLE
Refactor shapefile import to use Django's own DataSource API

### DIFF
--- a/imports/importers.py
+++ b/imports/importers.py
@@ -1,12 +1,17 @@
+import logging
+import os
 import zipfile
+from tempfile import gettempdir
 
-import shapefile
 from django.conf import settings
-from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.gdal import DataSource
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
 
-from nature.models import Feature
+from nature.models import Feature, FeatureClass
 
-REQUIRED_SHAPEFILE_EXTENSIONS = (".shp", ".shx", ".dbf")
+logger = logging.getLogger(__name__)
+
 SHAPEFILE_FIELD_MAPPING = {
     "id": "id",
     "tunnus": "fid",
@@ -25,17 +30,31 @@ SHAPEFILE_FIELD_MAPPING = {
 }
 
 
+def active_value_processor(value):
+    return value in ("t", 1)
+
+
+# Some shapefile field values cannot be directly used as
+# model field values. Those field values need to be
+# processed before saving to model instances
+FIELD_PROCESSORS = {"active": active_value_processor}
+
+
+class ImportValidationError(ValidationError):
+    pass
+
+
 class ShapefileImporter:
-    """A class that allow importing shapefile features to Feature model
+    """
+    A class that allow importing shapefile features to Feature model
+    The class makes a few assumptions on the input shapefile:
 
-    The class makes a few assumptions on the input shapefiles:
-
-    - The shapefiles must be valid, i.e.
+    - The shapefile must be valid, i.e.
         - all mandatory files (.shp, .shx and .dbf) are present
         - all files have same name prefix
         - the number of shapes and records must match
 
-    - The shapefiles must not include additional fields besides the ones
+    - The shapefile must not include additional fields besides the ones
     listed above and the names must match exactly. Basically they have
     same names as in database but shapefile has a 10 characters limit
     on field names.
@@ -43,54 +62,118 @@ class ShapefileImporter:
     - The shapefile may omit some of the fields that are not required by
     the Feature model.
 
-    - If a feature in shapefiles has an id that already exists in database,
+    - If a feature in shapefile has an id that already exists in database,
     then the importer will update the feature, otherwise it will create
     new ones.
     """
 
-    @classmethod
-    def import_features(cls, zipped_shapefiles):
-        shp_reader = cls._get_shp_reader(zipped_shapefiles)
-        fields = [
-            SHAPEFILE_FIELD_MAPPING[shape_field[0]]
-            for shape_field in shp_reader.fields[1:]
-        ]
-        for shape_record in shp_reader.iterShapeRecords():
-            cls._import_feature(fields, shape_record)
-        return shp_reader.numRecords
+    error_messages = {
+        "fields_not_allowed": _(
+            "Fields not allowed: %(fields)s. Allowed shapefile fields are: %(allowed_fields)s."
+        ),
+        "feature_classes_not_exist": _(
+            "Feature classes do not exist: %(feature_classes)s."
+        ),
+    }
 
     @classmethod
-    def _get_shp_reader(cls, zipped_shapefiles):
-        with zipfile.ZipFile(zipped_shapefiles) as zfile:
-            dbf, shp, shx = sorted(
-                [
-                    name
-                    for name in zfile.namelist()
-                    if name.endswith(REQUIRED_SHAPEFILE_EXTENSIONS)
-                ]
-            )
-            with zfile.open(dbf) as dbf, zfile.open(shp) as shp, zfile.open(shx) as shx:
-                return shapefile.Reader(shp=shp, shx=shx, dbf=dbf)
+    def import_features(cls, zipped_shapefile):
+        shapefile_importer = cls()
+        shp = shapefile_importer._extract_shapefile(zipped_shapefile)
+        data_source = DataSource(shp)
+        layer = data_source[0]  # shapefile always have one layer
+        shapefile_importer._validate_layer(layer)
+        shapefile_importer._import_layer(layer)
+        return len(layer)
 
-    @classmethod
-    def _import_feature(cls, fields, shape_record):
-        feature_data = dict(zip(fields, shape_record.record))
-        feature_data["geometry"] = cls._get_feature_geometry(shape_record.shape)
+    def _extract_shapefile(self, zipped_shapefile):
+        """
+        Extract all files within zipped shapefile to the temporary directory
 
-        feature_id = feature_data.pop("id", None)
-        try:
-            feature = Feature.objects.get(id=feature_id)
-            for key, value in feature_data.items():
-                setattr(feature, key, value)
-                feature.save()
-        except Feature.DoesNotExist:
-            Feature.objects.create(**feature_data)
+        :param zipped_shapefile: zipped shapefile
+        :return: the path to the shapefile shp file
+        """
+        temp_dir = gettempdir()
+        with zipfile.ZipFile(zipped_shapefile) as zip_ref:
+            zip_ref.extractall(temp_dir)
 
-    @classmethod
-    def _get_feature_geometry(cls, shape):
-        shape_type = shape.__geo_interface__["type"].upper()
-        coordinates = "{}".format(shape.__geo_interface__["coordinates"]).replace(
-            ",", " "
+        shapefile_name = next(
+            (name for name in zip_ref.namelist() if name.endswith(".shp")), None
         )
-        geostr = "SRID={};{}{}".format(settings.SRID, shape_type, coordinates)
-        return GEOSGeometry(geostr, srid=settings.SRID)
+        return os.path.join(temp_dir, shapefile_name)
+
+    def _validate_layer(self, layer):
+        """
+        Validate feature data in shapefile layer
+
+        :param layer: The shapefile data layer
+        """
+        self._validate_fields(layer)
+        self._validate_feature_classes(layer)
+
+    def _validate_fields(self, layer):
+        """
+        Validate layer fields
+
+        :param layer: The layer to be validated
+        :raise ImportValidationError: if invalid field found
+        """
+        layer_fields = layer.fields[1:]  # first field reserved as deletion flag
+        fields_not_allowed = set(layer_fields) - set(SHAPEFILE_FIELD_MAPPING.keys())
+        if fields_not_allowed:
+            error_code = "fields_not_allowed"
+            raise ImportValidationError(
+                self.error_messages[error_code],
+                code=error_code,
+                params={
+                    "fields": ", ".join(fields_not_allowed),
+                    "allowed_fields": ", ".join(SHAPEFILE_FIELD_MAPPING.keys()),
+                },
+            )
+
+    def _validate_feature_classes(self, layer):
+        """
+        Validate layer feature classes
+
+        :param layer: The layer to be validated
+        :raise ImportValidationError: if invalid feature class found
+        """
+        layer_feature_classes = set(layer.get_fields("luokkatunn"))
+        db_feature_classes = set(
+            FeatureClass.objects.filter(id__in=layer_feature_classes).values_list(
+                "id", flat=True
+            )
+        )
+        missing_feature_classes = layer_feature_classes - db_feature_classes
+        if missing_feature_classes:
+            error_code = "feature_classes_not_exist"
+            raise ImportValidationError(
+                self.error_messages[error_code],
+                code=error_code,
+                params={"feature_classes": ", ".join(missing_feature_classes)},
+            )
+
+    def _import_layer(self, layer):
+        """
+        Import features from shapefile layer
+
+        :param shapefile: The path to the shapefile shp file
+        """
+        if layer.srs and layer.srs.srid != settings.SRID:
+            logger.warning(f"Invalid projection {layer.srs.srid} will be ignored.")
+
+        for feature in layer:
+            feature_data = {}
+            for shapefile_field in layer.fields:
+                model_field = SHAPEFILE_FIELD_MAPPING.get(shapefile_field)
+                if model_field:
+                    processor = FIELD_PROCESSORS.get(model_field, lambda x: x)
+                    feature_data[model_field] = processor(
+                        feature[shapefile_field].value
+                    )
+            feature_id = feature_data.pop("id")
+            geometry = feature.geom.geos
+            # The geometries in shapefile must be using the same SRID as defined in settings
+            geometry.srid = settings.SRID
+            feature_data["geometry"] = geometry
+            Feature.objects.update_or_create(id=feature_id, defaults=feature_data)

--- a/imports/tests/test_importers.py
+++ b/imports/tests/test_importers.py
@@ -1,34 +1,154 @@
-import os
+import datetime
+from unittest.mock import patch
 
+from django.conf import settings
+from django.contrib.gis.geos import Point, Polygon
 from django.test import TestCase
 
 from nature.models import Feature
-from nature.tests.factories import FeatureFactory
-from .utils import ZippedShapefilesGenerator
-from ..importers import ShapefileImporter
+from nature.tests.factories import FeatureClassFactory, FeatureFactory
+from .utils import (
+    create_mock_zip_file_class,
+    MockFeature,
+    MockAttribute,
+    create_mock_data_source,
+)
+from ..importers import ShapefileImporter, ImportValidationError
+
+TEST_POINT = Point(10, 20, srid=settings.SRID)
+TEST_POLYGON = Polygon([(0, 0), (20, 20), (20, 0), (0, 0)], srid=settings.SRID)
+
+MOCK_FEATURE_1 = MockFeature(
+    {
+        "id": MockAttribute(1),
+        "tunnus": MockAttribute("f-1"),
+        "luokkatunn": MockAttribute("ABC"),
+        "nimi": MockAttribute("feature 1"),
+        "kuvaus": MockAttribute("feature 1 description"),
+        "huom": MockAttribute("feature 1 notes"),
+        "voimassa": MockAttribute("t"),
+        "digipvm": MockAttribute(datetime.date(2020, 10, 1)),
+        "numero": MockAttribute(1),
+        "digitoija": MockAttribute("test creator"),
+        "suojaustas": MockAttribute(3),
+        "pvm_editoi": MockAttribute(None),
+        "muokkaaja": MockAttribute(None),
+        "pinta_ala": MockAttribute(20),
+    },
+    TEST_POINT.ogr,
+)
+
+MOCK_FEATURE_2 = MockFeature(
+    {
+        "id": MockAttribute(2),
+        "tunnus": MockAttribute("f-2"),
+        "luokkatunn": MockAttribute("ABC"),
+        "nimi": MockAttribute("feature 2"),
+        "kuvaus": MockAttribute("feature 2 description"),
+        "huom": MockAttribute("feature 2 notes"),
+        "voimassa": MockAttribute("t"),
+        "digipvm": MockAttribute(datetime.date(2020, 11, 1)),
+        "numero": MockAttribute(1),
+        "digitoija": MockAttribute("test creator"),
+        "suojaustas": MockAttribute(3),
+        "pvm_editoi": MockAttribute(None),
+        "muokkaaja": MockAttribute(None),
+        "pinta_ala": MockAttribute(20),
+    },
+    TEST_POLYGON.ogr,
+)
+
+MOCK_FEATURE_WITH_INVALID_FIELD = MockFeature(
+    {
+        "id": MockAttribute(2),
+        "tunnus": MockAttribute("f-2"),
+        "luokkatunn": MockAttribute("ABC"),
+        "nimi": MockAttribute("feature 2"),
+        "kuvaus": MockAttribute("feature 2 description"),
+        "huom": MockAttribute("feature 2 notes"),
+        "voimassa": MockAttribute("t"),
+        "digipvm": MockAttribute(datetime.date(2020, 11, 1)),
+        "numero": MockAttribute(1),
+        "digitoija": MockAttribute("test creator"),
+        "suojaustas": MockAttribute(3),
+        "pvm_editoi": MockAttribute(None),
+        "muokkaaja": MockAttribute(None),
+        "pinta_ala": MockAttribute(20),
+        "an_invalid_field": MockAttribute(123),
+    },
+    TEST_POLYGON.ogr,
+)
+
+MOCK_FEATURE_WITH_INVALID_FEATURE_CLASS = MockFeature(
+    {
+        "id": MockAttribute(2),
+        "tunnus": MockAttribute("f-2"),
+        "luokkatunn": MockAttribute("INVALID-FEATURE-CLASS"),
+        "nimi": MockAttribute("feature 2"),
+        "kuvaus": MockAttribute("feature 2 description"),
+        "huom": MockAttribute("feature 2 notes"),
+        "voimassa": MockAttribute("t"),
+        "digipvm": MockAttribute(datetime.date(2020, 11, 1)),
+        "numero": MockAttribute(1),
+        "digitoija": MockAttribute("test creator"),
+        "suojaustas": MockAttribute(3),
+        "pvm_editoi": MockAttribute(None),
+        "muokkaaja": MockAttribute(None),
+        "pinta_ala": MockAttribute(20),
+    },
+    TEST_POLYGON.ogr,
+)
 
 
-class TestShapefileImporter(TestCase):
+class TestShapefilesImporter(TestCase):
     def setUp(self):
-        self.feature_1 = FeatureFactory()
-        self.feature_2 = FeatureFactory.build(
-            feature_class=self.feature_1.feature_class
+        self.feature_class = FeatureClassFactory(id="ABC")
+        self.feature_to_update = FeatureFactory(
+            name="feature-to-update", feature_class=self.feature_class
         )
 
+    @patch(
+        "imports.importers.DataSource",
+        create_mock_data_source([MOCK_FEATURE_1, MOCK_FEATURE_2]),
+    )
+    @patch(
+        "imports.importers.zipfile.ZipFile",
+        create_mock_zip_file_class(["test.shp", "test.shx", "test.dbf"]),
+    )
     def test_import(self):
         # make sure only feature 1 exist before importing
-        self.assertQuerysetEqual(Feature.objects.all(), [repr(self.feature_1)])
-
-        self.feature_1.name = "new name"
-        filename = ZippedShapefilesGenerator.create_shapefiles(
-            [self.feature_1, self.feature_2]
-        )
-        ShapefileImporter.import_features(filename)
-        os.remove(filename)
-
-        # new feature created
+        self.assertQuerysetEqual(Feature.objects.all(), [repr(self.feature_to_update)])
+        ShapefileImporter.import_features("dummy-shapefiles.zip")
+        # verify new feature created
         self.assertEqual(Feature.objects.count(), 2)
+        # verify existing feature updated
+        self.feature_to_update.refresh_from_db()
+        self.assertEqual(self.feature_to_update.name, "feature 1")
 
-        # existing feature updated
-        self.feature_1.refresh_from_db()
-        self.assertEqual(self.feature_1.name, "new name")
+    @patch(
+        "imports.importers.DataSource",
+        create_mock_data_source([MOCK_FEATURE_WITH_INVALID_FIELD]),
+    )
+    @patch(
+        "imports.importers.zipfile.ZipFile",
+        create_mock_zip_file_class(["test.shp", "test.shx", "test.dbf"]),
+    )
+    def test_raise_import_validation_error_if_layer_contains_invalid_fields(self):
+        with self.assertRaises(ImportValidationError) as context:
+            ShapefileImporter.import_features("dummy-shapefiles.zip")
+        self.assertEqual(context.exception.code, "fields_not_allowed")
+
+    @patch(
+        "imports.importers.DataSource",
+        create_mock_data_source([MOCK_FEATURE_WITH_INVALID_FEATURE_CLASS]),
+    )
+    @patch(
+        "imports.importers.zipfile.ZipFile",
+        create_mock_zip_file_class(["test.shp", "test.shx", "test.dbf"]),
+    )
+    def test_raise_import_validation_error_if_layer_contains_invalid_feature_classes(
+        self,
+    ):
+        with self.assertRaises(ImportValidationError) as context:
+            ShapefileImporter.import_features("dummy-shapefiles.zip")
+        self.assertEqual(context.exception.code, "feature_classes_not_exist")

--- a/imports/validators.py
+++ b/imports/validators.py
@@ -7,8 +7,9 @@ from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _
 
 from nature.models import FeatureClass
-from .importers import REQUIRED_SHAPEFILE_EXTENSIONS, SHAPEFILE_FIELD_MAPPING
+from .importers import SHAPEFILE_FIELD_MAPPING
 
+REQUIRED_SHAPEFILE_EXTENSIONS = (".shp", ".shx", ".dbf")
 
 @deconstructible
 class ZippedShapefilesValidator:

--- a/imports/validators.py
+++ b/imports/validators.py
@@ -1,15 +1,12 @@
 import os
 import zipfile
 
-import shapefile
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _
 
-from nature.models import FeatureClass
-from .importers import SHAPEFILE_FIELD_MAPPING
-
 REQUIRED_SHAPEFILE_EXTENSIONS = (".shp", ".shx", ".dbf")
+
 
 @deconstructible
 class ZippedShapefilesValidator:
@@ -17,12 +14,6 @@ class ZippedShapefilesValidator:
         "invalid_zipfile": _("%(filename)s is not a valid zip file."),
         "mismatched_filenames": _("Files do not have a common filename prefix."),
         "missing_required_files": _(".shp, .shx and .dbf files are required."),
-        "fields_not_allowed": _(
-            "Fields not allowed: %(fields)s. Allowed shapefile fields are: %(allowed_fields)s."
-        ),
-        "feature_classes_not_exist": _(
-            "Feature classes do not exist: %(feature_classes)s."
-        ),
     }
 
     def __call__(self, value):
@@ -35,19 +26,6 @@ class ZippedShapefilesValidator:
 
         with zipfile.ZipFile(value.file) as zfile:
             self._validate_files(zfile)
-
-            dbf, shp, shx = sorted(
-                [
-                    name
-                    for name in zfile.namelist()
-                    if name.endswith(REQUIRED_SHAPEFILE_EXTENSIONS)
-                ]
-            )
-            with zfile.open(shp) as shp, zfile.open(shx) as shx, zfile.open(dbf) as dbf:
-                shapefile_reader = shapefile.Reader(shp=shp, shx=shx, dbf=dbf)
-
-            self._validate_fields(shapefile_reader)
-            self._validate_feature_classes(shapefile_reader)
 
     def _validate_files(self, zfile):
         filenames, extensions = [], []
@@ -67,41 +45,4 @@ class ZippedShapefilesValidator:
             raise ValidationError(
                 self.messages["missing_required_files"],
                 code="missing_required_files",
-            )
-
-    def _validate_fields(self, shapefile_reader):
-        shapefile_fields = [
-            field[0] for field in shapefile_reader.fields[1:]
-        ]  # first field reserved as deletion flag
-        fields_not_allowed = set(shapefile_fields) - set(SHAPEFILE_FIELD_MAPPING.keys())
-        if fields_not_allowed:
-            raise ValidationError(
-                self.messages["fields_not_allowed"],
-                code="fields_not_allowed",
-                params={
-                    "fields": ", ".join(fields_not_allowed),
-                    "allowed_fields": ", ".join(SHAPEFILE_FIELD_MAPPING.keys()),
-                },
-            )
-
-    def _validate_feature_classes(self, shapefile_reader):
-        shapefile_fields = [
-            field[0] for field in shapefile_reader.fields[1:]
-        ]  # first field reserved as deletion flag
-        feature_class_column_index = shapefile_fields.index("luokkatunn")
-        feature_classes = {
-            record[feature_class_column_index]
-            for record in shapefile_reader.iterRecords()
-        }
-        db_feature_classes = set(
-            FeatureClass.objects.filter(id__in=feature_classes).values_list(
-                "id", flat=True
-            )
-        )
-        missing_feature_classes = feature_classes - db_feature_classes
-        if missing_feature_classes:
-            raise ValidationError(
-                self.messages["feature_classes_not_exist"],
-                code="feature_classes_not_exist",
-                params={"feature_classes": ", ".join(missing_feature_classes)},
             )


### PR DESCRIPTION
This PR refactors the  ShapefileImporter to use Django's own DataSource API instead of the third party library. Django's DataSource API is nicer to work with and we do not need to worry about the compatibility issues when upgrading Django. And at the mean time it fixes the issue #267 

Refs: #267