### PR TITLE
Fix python 3.8 failing tests

### DIFF
--- a/imports/tests/test_models.py
+++ b/imports/tests/test_models.py
@@ -2,16 +2,15 @@ import os
 
 from django.test import TestCase
 
-from nature.tests.utils import make_user
 from .factories import ShapefileImportFactory
 
 
 class TestShapefileImport(TestCase):
     def setUp(self):
-        self.shp_import = ShapefileImportFactory(created_by=make_user())
+        self.shp_import = ShapefileImportFactory()
 
     def tearDown(self):
         os.remove(self.shp_import.shapefiles.path)
 
     def test__str__(self):
-        self.assertEqual(self.shp_import.__str__(), "shapefiles/testshapefiles.zip")
+        self.assertTrue(str(self.shp_import).startswith("shapefiles/testshapefiles"))

--- a/nature/hmac.py
+++ b/nature/hmac.py
@@ -157,6 +157,8 @@ class HMACAuth:
 
     def _generate_signature(self, algorithm, message):
         digestmod = self.DIGEST_ALGORITHMS.get(algorithm)
+        if not digestmod:
+            raise InvalidAuthorization()
         hmac_obj = hmac.HMAC(
             key=settings.SHARED_SECRET.encode("utf-8"),
             msg=message.encode("utf-8"),

--- a/nature/tests/test_hmac.py
+++ b/nature/tests/test_hmac.py
@@ -119,7 +119,7 @@ class TestHMACAuth(TestCase):
             hmac_auth.is_valid
 
     @freeze_time("2017-06-22 17:16:00")
-    def test_is_valid_return_false_for_invalid_digest_algorithm(self):
+    def test_is_valid_raise_exception_for_invalid_digest_algorithm(self):
         request = self.factory.get(
             "/test-url/",
             HTTP_DATE="Thu, 22 Jun 2017 17:15:21 GMT",
@@ -134,7 +134,8 @@ class TestHMACAuth(TestCase):
             ),
         )
         hmac_auth = HMACAuth(request)
-        self.assertFalse(hmac_auth.is_valid)
+        with self.assertRaises(InvalidAuthorization):
+            hmac_auth.is_valid
 
     @freeze_time("2017-06-22 17:16:00")
     def test_is_valid_return_false_if_invalid_signature(self):


### PR DESCRIPTION
This PR fixes two problematic tests:

- Fix test__str__ in impors. The tests are run in random order and the test shapefile may have already been created when running test__str__. In such cases, an suffix will be appended to the filename to avoid collision.

- Raise InvalidAuthorization if invalid digest algorithm provided. The test that tests invalid hmac digest algorithm was failing because starting from Python 3.8, digestmod is a required parameter for HMAC. 

no refs