### PR TITLE
Fix improper handling of the id field

### DIFF
--- a/imports/admin.py
+++ b/imports/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.contrib import messages
 from django.db import transaction
-from django.utils.translation import ugettext as _
 
 from .models import ShapefileImport
 from .importers import ShapefileImporter, ImportValidationError
@@ -17,12 +16,9 @@ class ShapefileImportAdmin(admin.ModelAdmin):
         if not obj.pk:
             # only do imports when creating new instances
             try:
-                num_features = ShapefileImporter.import_features(obj.shapefiles)
-                messages.add_message(
-                    request,
-                    messages.INFO,
-                    _("{0} features were imported").format(num_features),
-                )
+                import_log = ShapefileImporter.import_features(obj.shapefiles)
+                for level, msg in import_log:
+                    messages.add_message(request, level, msg)
                 obj.created_by = request.user
             except ImportValidationError as e:
                 for message in e.messages:

--- a/imports/tests/test_admin.py
+++ b/imports/tests/test_admin.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import patch
 
+from django.contrib import messages
 from django.contrib.admin import AdminSite
 from django.test import TestCase, RequestFactory
 
@@ -18,7 +19,10 @@ class TestShapefileImportAdmin(TestCase):
         self.shp_import = ShapefileImportFactory.build()
 
     @patch("imports.admin.messages.add_message")
-    @patch("imports.importers.ShapefileImporter.import_features")
+    @patch(
+        "imports.importers.ShapefileImporter.import_features",
+        return_value=[(messages.INFO, "1 feature imported")],
+    )
     def test_save_model(self, mock_import, mock_add_message):
         shp_import_admin = ShapefileImportAdmin(ShapefileImport, self.site)
         request = self.factory.get("/fake-url/")

--- a/imports/tests/test_importers.py
+++ b/imports/tests/test_importers.py
@@ -40,7 +40,7 @@ MOCK_FEATURE_1 = MockFeature(
 
 MOCK_FEATURE_2 = MockFeature(
     {
-        "id": MockAttribute(2),
+        "id": MockAttribute(0),
         "tunnus": MockAttribute("f-2"),
         "luokkatunn": MockAttribute("ABC"),
         "nimi": MockAttribute("feature 2"),
@@ -60,7 +60,7 @@ MOCK_FEATURE_2 = MockFeature(
 
 MOCK_FEATURE_WITH_INVALID_FIELD = MockFeature(
     {
-        "id": MockAttribute(2),
+        "id": MockAttribute(0),
         "tunnus": MockAttribute("f-2"),
         "luokkatunn": MockAttribute("ABC"),
         "nimi": MockAttribute("feature 2"),
@@ -81,7 +81,7 @@ MOCK_FEATURE_WITH_INVALID_FIELD = MockFeature(
 
 MOCK_FEATURE_WITH_INVALID_FEATURE_CLASS = MockFeature(
     {
-        "id": MockAttribute(2),
+        "id": MockAttribute(0),
         "tunnus": MockAttribute("f-2"),
         "luokkatunn": MockAttribute("INVALID-FEATURE-CLASS"),
         "nimi": MockAttribute("feature 2"),


### PR DESCRIPTION
The id field of Feature model is an AutoField, and we'll never
create a new feature with an id assigned in shapefiles. The id
value will be used to update existing features. And if the id
does not exist, a warning is raised to the user.

Refs: #267