### PR TITLE
Improve the logic to handle invalid hmac requests

### DIFF
--- a/nature/hmac.py
+++ b/nature/hmac.py
@@ -74,7 +74,11 @@ class HMACAuth:
     def user_role(self):
         # seen as public access if no auth header provided
         if not self.auth_header:
-            return UserRole.PUBLIC
+            event = self._get_event(
+                "no-auth", "Authorization failed: no auth header provided"
+            )
+            capture_event(event)
+            raise PermissionDenied()
 
         if not self.is_valid:
             event = self._get_event(
@@ -90,11 +94,7 @@ class HMACAuth:
         elif self.has_office_group:
             return UserRole.OFFICE
         else:
-            event = self._get_event(
-                "invalid-group", "Authorization failed: invalid group provided"
-            )
-            capture_event(event)
-            raise PermissionDenied()
+            return UserRole.PUBLIC
 
     @property
     def within_clock_skew(self):

--- a/nature/views.py
+++ b/nature/views.py
@@ -74,9 +74,12 @@ class ProtectedObservationListReportViewMixin(ProtectedReportViewMixin):
     def get_filtered_observations(self):
         """Get filtered observations based on hmac user roles"""
         qs = self.get_observation_queryset()
+        if self.request.user.is_staff:
+            return qs
+
         hmac_auth = self._get_hmac_auth()
         role = hmac_auth.user_role
-        if self.request.user.is_staff or role == UserRole.ADMIN:
+        if role == UserRole.ADMIN:
             qs = qs.for_admin()
         elif role == UserRole.OFFICE_HKI:
             qs = qs.for_office_hki()
@@ -88,6 +91,9 @@ class ProtectedObservationListReportViewMixin(ProtectedReportViewMixin):
 
     def get_secret_observation_count(self):
         """Return the number of secret observations for current user role"""
+        if self.request.user.is_staff:
+            return 0
+
         hmac_auth = self._get_hmac_auth()
         user_role = hmac_auth.user_role
 


### PR DESCRIPTION
According to request specs (SpatialWeb client that request reports from ltj),
the X-forwarded-Group header is empty for 1) anonymous users (public
profile); 2) users who don't have nay roles. Thus a request without group
information or with invalid group information are vaild requests and can
access public reports. However, if a request that misses the Authorization
header or the authorization header is invalid, then the access should be denied.

Aslo the reports can only be accessed via spatial web proxy with hmac requests,
a normal django user is not able to access any reports.

Refs: #291