### PR TITLE
Restore paging

### DIFF
--- a/ltj/settings.py
+++ b/ltj/settings.py
@@ -167,6 +167,7 @@ WSGI_APPLICATION = "ltj.wsgi.application"
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
+    "DEFAULT_AUTHENTICATION_CLASSES": ("helusers.oidc.ApiTokenAuthentication",),
 }
 
 DATABASES = {
@@ -212,10 +213,6 @@ LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
-
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": ("helusers.oidc.ApiTokenAuthentication",),
-}
 
 OIDC_API_TOKEN_AUTH = {
     "AUDIENCE": env("OIDC_AUDIENCE"),


### PR DESCRIPTION
Paging was broken by addition of duplicate DRF configuration dict
during implementation of token authentication.